### PR TITLE
Card listing variation

### DIFF
--- a/src/components/Blocks/Card/index.js
+++ b/src/components/Blocks/Card/index.js
@@ -1,4 +1,5 @@
 import CardEdit from './Edit';
+import CardSchema from './schema';
 import CardView from './View';
 
-export { CardEdit, CardView };
+export { CardEdit, CardView, CardSchema };

--- a/src/components/Blocks/Card/schema.js
+++ b/src/components/Blocks/Card/schema.js
@@ -55,6 +55,7 @@ export const cardSchema = ({ intl }) => {
         id: 'default',
         title: 'Default',
         fields: ['title', 'description', 'link', 'image'],
+        required: [],
       },
       {
         id: 'styling',
@@ -65,6 +66,7 @@ export const cardSchema = ({ intl }) => {
           'colour',
           'imagePosition',
         ],
+        required: [],
       },
     ],
     properties: {

--- a/src/components/Blocks/Listing/CardListing.jsx
+++ b/src/components/Blocks/Listing/CardListing.jsx
@@ -1,0 +1,27 @@
+import { ConditionalLink } from '@plone/volto/components';
+import React from 'react';
+import { CardView } from '../Card';
+
+const numberOfColumnsClassMapping = {
+  1: 'nsw-col',
+  2: 'nsw-col nsw-col-md-6',
+  3: 'nsw-col nsw-col-md-6 nsw-col-lg-4',
+  4: 'nsw-col nsw-col-md-6 nsw-col-lg-3',
+};
+
+const CardListing = ({ items, isEditMode, ...data }) => {
+  return (
+    <div className="nsw-grid">
+      {items.map((item) => (
+        <div
+          key={item['@id']}
+          className={numberOfColumnsClassMapping[data.numberOfColumns]}
+        >
+          <CardView data={{ ...data, ...item }} isEditMode={isEditMode} />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default CardListing;

--- a/src/config/blocks.js
+++ b/src/config/blocks.js
@@ -3,17 +3,14 @@ import { defineMessages } from 'react-intl';
 // Todo: Setup path imports for blocks
 import config from '@plone/volto/registry';
 import * as Components from '../components';
+import { CardSchema } from '../components/Blocks/Card';
 import { DropdownQuickNavigationSchema } from '../components/Blocks/DropdownQuickNavigation/schema';
-import ListItems from '../customizations/volto/components/manage/Blocks/Search/layout/ListItems';
+import CardListing from '../components/Blocks/Listing/CardListing';
 
 const messages = defineMessages({
   card: {
     id: 'Card',
     defaultMessage: 'Card',
-  },
-  listItems: {
-    id: 'List Items',
-    defaultMessage: 'List Items',
   },
   searchFacetsTitleDefault: {
     id: 'Filter results',
@@ -30,6 +27,11 @@ const messages = defineMessages({
   imagePosition: {
     id: 'Image position',
     defaultMessage: 'Image position',
+  },
+  // Card listing schema
+  numberOfColumns: {
+    id: 'Number of columns',
+    defaultMessage: 'Number of columns',
   },
 });
 
@@ -150,7 +152,13 @@ const nswBlocks = [
 ];
 
 const blockVariations = {
-  listing: [],
+  listing: [
+    {
+      id: 'cardListing',
+      title: 'Card list',
+      template: CardListing,
+    },
+  ],
   hero: [
     {
       id: 'default',
@@ -206,6 +214,40 @@ const schemaEnhancers = {
 // Add schema enhancers to specific variations of existing blocks
 const variationSchemaEnhancers = {
   listing: {
+    cardListing: ({ schema, intl }) => {
+      // Add the card display settings to the listing settings
+      const cardSchema = CardSchema({
+        intl,
+      });
+      schema.properties = {
+        ...schema.properties,
+        ...cardSchema.properties,
+      };
+      const stylingFieldsetIndex = 1;
+      const variationFieldset = {
+        id: 'cardListingVariation',
+        title: 'Card Display Settings',
+        fields: [...cardSchema.fieldsets[stylingFieldsetIndex].fields],
+        required: [...cardSchema.fieldsets[stylingFieldsetIndex].required],
+      };
+      schema.fieldsets.push(variationFieldset);
+
+      // Add the custom settings
+      schema.properties.numberOfColumns = {
+        title: intl.formatMessage(messages.numberOfColumns),
+        type: 'number',
+        minimum: 1,
+        maximum: 4,
+        default: 3,
+      };
+      // 0 is the default fieldset
+      schema.fieldsets[0].fields = [
+        ...schema.fieldsets[0].fields,
+        'numberOfColumns',
+      ];
+
+      return schema;
+    },
     imageGallery: ({ schema, intl }) => {
       const imageSettingFieldset = {
         id: 'imageSettings',


### PR DESCRIPTION
This PR adds a 'Card listing' variation to the listing block. This allows auto-generated lists of cards to be shown rather than the manual curation of each card. All styling options available to the card block can be applied to the cards in the listing and the number of each columns in a row can be customised between 1 and 4.

## Editing video

The below video demonstrates the editing of the card block

https://user-images.githubusercontent.com/30210785/189178115-28d369ad-bcc9-4633-80aa-0fafdb85cd02.mov

