### PR TITLE
Video and image block display fixes

### DIFF
--- a/src/config/blocks.js
+++ b/src/config/blocks.js
@@ -258,16 +258,18 @@ function asMediaSchemaExtender(schema, intl, formData) {
     ],
   };
   // TODO: 0 is the 'default' fieldset, but should look it up for safety.
-  schema.fieldsets[0].fields = [
-    ...schema.fieldsets[0].fields,
-    'size',
-    'caption',
-  ];
+  schema.fieldsets[0].fields = [...schema.fieldsets[0].fields, 'caption'];
+  if (!schema.fieldsets[0].fields.includes('size')) {
+    schema.fieldsets[0].fields = [...schema.fieldsets[0].fields, 'size'];
+  }
   return schema;
 }
 
 const schemaEnhancers = {
   video: ({ schema, intl, formData }) => {
+    return asMediaSchemaExtender(schema, intl, formData);
+  },
+  image: ({ schema, intl, formData }) => {
     return asMediaSchemaExtender(schema, intl, formData);
   },
   search: ({ schema, intl }) => {

--- a/src/config/blocks.js
+++ b/src/config/blocks.js
@@ -33,6 +33,19 @@ const messages = defineMessages({
     id: 'Number of columns',
     defaultMessage: 'Number of columns',
   },
+  // Media schema
+  size: {
+    id: 'Size',
+    defaultMessage: 'Size',
+  },
+  caption: {
+    id: 'Caption',
+    defaultMessage: 'Caption',
+  },
+  captionBackgroundColour: {
+    id: 'Caption background colour',
+    defaultMessage: 'Caption background colour',
+  },
 });
 
 // Todo: i18n for component titles and groups
@@ -192,7 +205,71 @@ const blockVariations = {
   ],
 };
 
+const alignmentPositionSizeMapping = {
+  center: [
+    ['fullWidth', 'Full width'],
+    ['90', '90%'],
+    ['80', '80%'],
+    ['70', '70%'],
+    ['60', '60%'],
+  ],
+  left: [
+    ['50', '50%'],
+    ['40', '40%'],
+    ['30', '30%'],
+  ],
+  right: [
+    ['50', '50%'],
+    ['40', '40%'],
+    ['30', '30%'],
+  ],
+};
+
+function asMediaSchemaExtender(schema, intl, formData) {
+  schema.properties.align.actions = ['center', 'left', 'right'];
+  schema.properties.size = {
+    title: intl.formatMessage(messages.size),
+    type: 'string',
+    factory: 'Choice',
+    choices: formData.align
+      ? alignmentPositionSizeMapping[formData.align]
+      : alignmentPositionSizeMapping['center'],
+    default: formData.align
+      ? alignmentPositionSizeMapping[formData.align][0]
+      : 'fullWidth',
+    value: formData.size
+      ? formData.size
+      : formData.align
+      ? alignmentPositionSizeMapping[formData.align][0]
+      : 'fullWidth',
+  };
+  schema.properties.caption = {
+    title: intl.formatMessage(messages.caption),
+    type: 'string',
+  };
+  schema.properties.captionBackgroundColour = {
+    title: intl.formatMessage(messages.captionBackgroundColour),
+    type: 'string',
+    factory: 'Choice',
+    choices: [
+      ['dark', 'Dark'],
+      ['light', 'Light'],
+      ['transparent', 'No background'],
+    ],
+  };
+  // TODO: 0 is the 'default' fieldset, but should look it up for safety.
+  schema.fieldsets[0].fields = [
+    ...schema.fieldsets[0].fields,
+    'size',
+    'caption',
+  ];
+  return schema;
+}
+
 const schemaEnhancers = {
+  video: ({ schema, intl, formData }) => {
+    return asMediaSchemaExtender(schema, intl, formData);
+  },
   search: ({ schema, intl }) => {
     schema.properties.facetsTitle.default = intl.formatMessage(
       messages.searchFacetsTitleDefault,

--- a/src/customizations/volto/components/manage/Blocks/Image/View.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Image/View.jsx
@@ -1,0 +1,95 @@
+/**
+ * View image block.
+ * @module components/manage/Blocks/Image/View
+ */
+
+import { UniversalLink } from '@plone/volto/components';
+import {
+  flattenToAppURL,
+  isInternalURL,
+  withBlockExtensions,
+} from '@plone/volto/helpers';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * View image block class.
+ * @class View
+ * @extends Component
+ */
+export const View = ({ data, detached }) => {
+  const href = data?.href?.[0]?.['@id'] || '';
+  return (
+    <p
+      className={cx(
+        'block image align',
+        {
+          center: !Boolean(data.align),
+          detached,
+        },
+        data.align,
+      )}
+    >
+      {data.url && (
+        <>
+          {(() => {
+            const image = (
+              <img
+                className={cx({
+                  'full-width': data.align === 'full',
+                  large: data.size === 'l',
+                  medium: data.size === 'm',
+                  small: data.size === 's',
+                })}
+                src={
+                  isInternalURL(data.url)
+                    ? // Backwards compat in the case that the block is storing the full server URL
+                      (() => {
+                        if (data.size === 'l')
+                          return `${flattenToAppURL(data.url)}/@@images/image`;
+                        if (data.size === 'm')
+                          return `${flattenToAppURL(
+                            data.url,
+                          )}/@@images/image/preview`;
+                        if (data.size === 's')
+                          return `${flattenToAppURL(
+                            data.url,
+                          )}/@@images/image/mini`;
+                        return `${flattenToAppURL(data.url)}/@@images/image`;
+                      })()
+                    : data.url
+                }
+                alt={data.alt || ''}
+                loading="lazy"
+              />
+            );
+            if (href) {
+              return (
+                <UniversalLink
+                  href={href}
+                  openLinkInNewTab={data.openLinkInNewTab}
+                >
+                  {image}
+                </UniversalLink>
+              );
+            } else {
+              return image;
+            }
+          })()}
+        </>
+      )}
+    </p>
+  );
+};
+
+/**
+ * Property types.
+ * @property {Object} propTypes Property types.
+ * @static
+ */
+View.propTypes = {
+  data: PropTypes.objectOf(PropTypes.any).isRequired,
+};
+
+export default withBlockExtensions(View);

--- a/src/customizations/volto/components/manage/Blocks/Image/View.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Image/View.jsx
@@ -21,15 +21,16 @@ import React from 'react';
 export const View = ({ data, detached }) => {
   const href = data?.href?.[0]?.['@id'] || '';
   return (
-    <p
-      className={cx(
-        'block image align',
-        {
-          center: !Boolean(data.align),
-          detached,
-        },
-        data.align,
-      )}
+    <figure
+      className={cx('nsw-media', {
+        [`nsw-media--${data.captionBackgroundColour}`]: !!data.captionBackgroundColour,
+        [`nsw-media--${data.size}`]:
+          !!data.size &&
+          !['left', 'right'].includes(data.align) &&
+          data.size !== 'fullWidth',
+        [`nsw-media--${data.align}-${data.size}`]:
+          !!data.size && !!data.align && data.size !== 'fullWidth',
+      })}
     >
       {data.url && (
         <>
@@ -79,7 +80,8 @@ export const View = ({ data, detached }) => {
           })()}
         </>
       )}
-    </p>
+      {data.caption ? <figcaption>{data.caption}</figcaption> : null}
+    </figure>
   );
 };
 

--- a/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
@@ -57,7 +57,17 @@ const Body = ({ data, isEditMode }) => {
   };
 
   return (
-    <figure className={cx('nsw-media', {})}>
+    <figure
+      className={cx('nsw-media', {
+        [`nsw-media--${data.captionBackgroundColour}`]: !!data.captionBackgroundColour,
+        [`nsw-media--${data.size}`]:
+          !!data.size &&
+          !['left', 'right'].includes(data.align) &&
+          data.size !== 'fullWidth',
+        [`nsw-media--${data.align}-${data.size}`]:
+          !!data.size && !!data.align && data.size !== 'fullWidth',
+      })}
+    >
       <div className="nsw-media__video">
         {data.url ? (
           <>
@@ -137,10 +147,7 @@ const Body = ({ data, isEditMode }) => {
           </>
         ) : null}
       </div>
-      <figcaption>
-        A long caption, ee mei labores adipiscing, nonumy reprehendunt ex mea
-        umo tota has at, clita bonorum erroribus vis ne.
-      </figcaption>
+      {data.caption ? <figcaption>{data.caption}</figcaption> : null}
     </figure>
   );
 };

--- a/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
@@ -1,0 +1,148 @@
+import { flattenToAppURL, isInternalURL } from '@plone/volto/helpers';
+import cx from 'classnames';
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { Message } from 'semantic-ui-react';
+
+const Body = ({ data, isEditMode }) => {
+  let placeholder = data.preview_image
+    ? isInternalURL(data.preview_image)
+      ? `${flattenToAppURL(data.preview_image)}/@@images/image`
+      : data.preview_image
+    : null;
+
+  let videoID = null;
+  let listID = null;
+
+  if (data.url) {
+    if (data.url.match('youtu')) {
+      if (data.url.match('list')) {
+        const matches = data.url.match(/^.*\?list=(.*)|^.*&list=(.*)$/);
+        listID = matches[1] || matches[2];
+      } else {
+        videoID = data.url.match(/.be\//)
+          ? data.url.match(/^.*\.be\/(.*)/)[1]
+          : data.url.match(/^.*\?v=(.*)$/)[1];
+      }
+
+      if (!placeholder) {
+        //load video preview image from youtube
+        placeholder =
+          'https://img.youtube.com/vi/' + videoID + '/sddefault.jpg';
+      }
+    } else if (data.url.match('vimeo')) {
+      videoID = data.url.match(/^.*\.com\/(.*)/)[1];
+      if (!placeholder) {
+        placeholder = 'https://vumbnail.com/' + videoID + '.jpg';
+      }
+    }
+  }
+
+  const ref = React.createRef();
+  const onKeyDown = (e) => {
+    if (e.nativeEvent.keyCode === 13) {
+      ref.current.handleClick();
+    }
+  };
+
+  const embedSettings = {
+    placeholder: placeholder,
+    icon: 'play',
+    defaultActive: false,
+    autoplay: false,
+    aspectRatio: '16:9',
+    tabIndex: 0,
+    onKeyPress: onKeyDown,
+    ref: ref,
+  };
+
+  return (
+    <figure className={cx('nsw-media', {})}>
+      <div className="nsw-media__video">
+        {data.url ? (
+          <>
+            {data.url.match('youtu') ? (
+              <>
+                {data.url.match('list') ? (
+                  <iframe
+                    src={`https://www.youtube.com/embed/videoseries?list=${listID}`}
+                    title="Digital.nsw launch with Victor Dominello MP at NSW Parliament House"
+                    style={{ border: 0 }}
+                    allowFullScreen
+                  ></iframe>
+                ) : (
+                  <>
+                    <iframe
+                      src={`https://www.youtube.com/embed/${videoID}`}
+                      title="Digital.nsw launch with Victor Dominello MP at NSW Parliament House"
+                      style={{ border: 0 }}
+                      allowFullScreen
+                    ></iframe>
+                  </>
+                )}
+              </>
+            ) : (
+              <>
+                {data.url.match('vimeo') ? (
+                  <iframe
+                    src={`https://player.vimeo.com/video/${videoID}?api=false&amp;autoplay=false&amp;byline=false&amp;portrait=false&amp;title=false`}
+                    title="Digital.nsw launch with Victor Dominello MP at NSW Parliament House"
+                    style={{ border: 0 }}
+                    allowFullScreen
+                  ></iframe>
+                ) : (
+                  //
+                  // <Embed id={videoID} source="vimeo" {...embedSettings} />
+                  <>
+                    {data.url.match('.mp4') ? (
+                      // eslint-disable-next-line jsx-a11y/media-has-caption
+                      <video
+                        // Style tag is needed for sizing. See https://github.com/digitalnsw/nsw-design-system/pull/252
+                        style={{
+                          position: 'absolute',
+                          top: 0,
+                          left: 0,
+                          width: '100$',
+                          height: '100%',
+                        }}
+                        src={
+                          isInternalURL(data.url)
+                            ? data.url.includes('@@download')
+                              ? data.url
+                              : `${flattenToAppURL(data.url)}/@@download/file`
+                            : data.url
+                        }
+                        controls
+                        poster={placeholder}
+                        type="video/mp4"
+                      />
+                    ) : isEditMode ? (
+                      <div>
+                        <Message>
+                          <center>
+                            <FormattedMessage
+                              id="Please enter a valid URL by deleting the block and adding a new video block."
+                              defaultMessage="Please enter a valid URL by deleting the block and adding a new video block."
+                            />
+                          </center>
+                        </Message>
+                      </div>
+                    ) : (
+                      <div className="invalidVideoFormat" />
+                    )}
+                  </>
+                )}
+              </>
+            )}
+          </>
+        ) : null}
+      </div>
+      <figcaption>
+        A long caption, ee mei labores adipiscing, nonumy reprehendunt ex mea
+        umo tota has at, clita bonorum erroribus vis ne.
+      </figcaption>
+    </figure>
+  );
+};
+
+export default Body;

--- a/src/customizations/volto/components/manage/Blocks/Video/View.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/View.jsx
@@ -1,6 +1,5 @@
 import Body from '@plone/volto/components/manage/Blocks/Video/Body';
 import { withBlockExtensions } from '@plone/volto/helpers';
-import PropTypes from 'prop-types';
 import React from 'react';
 
 const View = ({ data }) => {

--- a/src/customizations/volto/components/manage/Blocks/Video/View.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/View.jsx
@@ -1,0 +1,10 @@
+import Body from '@plone/volto/components/manage/Blocks/Video/Body';
+import { withBlockExtensions } from '@plone/volto/helpers';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const View = ({ data }) => {
+  return <Body data={data} />;
+};
+
+export default withBlockExtensions(View);


### PR DESCRIPTION
This PR fixes the Image and Video block views not using the `nsw-media` wrapper, causing it to become misaligned with the page contents. Additionally, other options for the media sizing as well as adding a caption have been added to both blocks.

<img width="254" alt="" src="https://user-images.githubusercontent.com/30210785/192075888-c400f031-afd2-44ce-b03c-0e5162751047.png">
<img width="252" alt="" src="https://user-images.githubusercontent.com/30210785/192075892-f479f836-9eb8-4bef-9872-eabdec45181e.png">
