### PR TITLE
Fix other addon's routes and reducers not loading

### DIFF
--- a/src/config/reducers.js
+++ b/src/config/reducers.js
@@ -1,7 +1,7 @@
 import customReducers from '../reducers';
 
 export const applyReducersConfig = (config) => {
-  config.addonReducers = { ...customReducers };
+  config.addonReducers = { ...customReducers, ...config.addonReducers };
 };
 
 export default applyReducersConfig;

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -17,6 +17,7 @@ export const updateRoutesConfig = (config) => {
   });
 
   config.addonRoutes = [
+    ...config.addonRoutes,
     {
       path: '/search',
       component: View,


### PR DESCRIPTION
This addon was overriding the `addonRoutes` and `addonReducers` rather than extending them, breaking other addons which relied on using either of these properties. This PR fixes this.