### PR TITLE
Option to hide site title

### DIFF
--- a/src/config/asyncConnect.js
+++ b/src/config/asyncConnect.js
@@ -14,9 +14,11 @@ export const updateAsyncConnectConfig = (config) => {
         ) {
           dispatchActions.push({
             key: 'nswSiteSettings',
-            promise: ({ location, store: { dispatch } }) => {
+            promise: async ({ location, store: { dispatch } }) => {
               __SERVER__ &&
-                dispatch(getNswSiteSettings(getBaseUrl(location.pathname)));
+                (await dispatch(
+                  getNswSiteSettings(getBaseUrl(location.pathname)),
+                ));
             },
           });
         }

--- a/src/customizations/volto/components/theme/Footer/Footer.jsx
+++ b/src/customizations/volto/components/theme/Footer/Footer.jsx
@@ -79,12 +79,10 @@ function Footer() {
     (item, index) => index !== lowerFooterLinksIndex,
   );
 
-  console.log('nswSettings', siteSettings);
-
   const socialFieldsToDisplay = Object.keys(socialFieldIconMapping).filter(
-    (fieldname) => siteSettings[fieldname] && !!siteSettings[fieldname],
+    (fieldname) =>
+      siteSettings && siteSettings[fieldname] && !!siteSettings[fieldname],
   );
-  console.log('socialIcons', socialFieldsToDisplay);
 
   return (
     <>
@@ -190,8 +188,6 @@ function Footer() {
                     const { href, socialName, Logo } = socialFieldIconMapping[
                       fieldname
                     ];
-
-                    console.log(fieldname, href, socialName);
 
                     return (
                       <a

--- a/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/src/customizations/volto/components/theme/Header/Header.jsx
@@ -60,9 +60,9 @@ const SearchStartButton = ({ searchInputElement }) => {
 };
 
 const Header = ({ nswDesignSystem }) => {
-  const { token, siteTitle } = useSelector((state) => ({
-    token: state.userSession.token,
+  const { siteSettings, siteTitle } = useSelector((state) => ({
     siteTitle: state.siteInfo.title,
+    siteSettings: state.nswSiteSettings.data,
   }));
   const { pathname } = useLocation();
   const searchInputElement = useRef(null);
@@ -88,9 +88,11 @@ const Header = ({ nswDesignSystem }) => {
               <div className="nsw-header__waratah">
                 <Logo />
               </div>
-              <div className="nsw-header__name">
-                <div className="nsw-header__title">{siteTitle}</div>
-              </div>
+              {siteSettings && !siteSettings.show_site_title_text ? null : (
+                <div className="nsw-header__name">
+                  <div className="nsw-header__title">{siteTitle}</div>
+                </div>
+              )}
             </div>
             <MenuOpenButton />
             <SearchStartButton searchInputElement={searchInputElement} />

--- a/src/customizations/volto/components/theme/Logo/Logo.jsx
+++ b/src/customizations/volto/components/theme/Logo/Logo.jsx
@@ -15,7 +15,7 @@ const Logo = () => {
   return (
     <UniversalLink href={settings.isMultilingual ? `/${lang}` : '/'}>
       {logoUrl && !logoUrl.includes('++resource++plone-logo.svg') ? (
-        <img style={{ height: '4.75rem' }} src={logoUrl} alt={siteTitle} />
+        <img style={{ height: '4.75rem' }} src={logoUrl} alt="" />
       ) : (
         <>
           <svg
@@ -46,7 +46,7 @@ const Logo = () => {
               fill="#D7153A"
             ></path>
           </svg>
-          <span className="sr-only">NSW Government</span>
+          <span className="sr-only">{siteTitle}</span>
         </>
       )}
     </UniversalLink>


### PR DESCRIPTION
This PR allows site admins to hide the text part of the site title. This is currently labeled as 'independent only', but could be used on co-brand and masterbrand sites depending on the service.