### PR TITLE
Unfocus hero editor when it is deselected

### DIFF
--- a/src/customizations/volto/components/manage/Blocks/HeroImageLeft/Edit.jsx
+++ b/src/customizations/volto/components/manage/Blocks/HeroImageLeft/Edit.jsx
@@ -296,7 +296,12 @@ class EditComponent extends Component {
       });
     }
 
-    if (nextProps.selected !== this.props.selected) {
+    if (!nextProps.selected) {
+      this.titleEditor.editor.blur();
+      this.descriptionEditor.editor.blur();
+    }
+
+    if (nextProps.selected && !this.props.selected) {
       if (this.state.currentFocused === 'title') {
         this.titleEditor.focus();
       } else {


### PR DESCRIPTION
This PR fixes the focus issues noted in pretagov/nsw-demo#154

I haven't added the block creation part of this as [another volto PR](https://github.com/plone/volto/pull/3386) seems to rewrite the Hero block and is due for addition to Plone 6.0