### PR TITLE
Add Google Analytics support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@eeacms/volto-accordion-block",
     "@kitconcept/volto-blocks-grid",
     "volto-form-block",
+    "volto-google-analytics",
     "volto-subfooter",
     "volto-siteinfo"
   ],
@@ -30,6 +31,7 @@
     "nsw-design-system": "3.2.4",
     "react-color": "2.19.3",
     "volto-form-block": "3.0.0",
+    "volto-google-analytics": "2.0.0",
     "volto-siteinfo": "1.0.1",
     "volto-subblocks": "2.0.0",
     "volto-subfooter": "2.0.0"

--- a/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/src/customizations/volto/components/theme/Header/Header.jsx
@@ -9,6 +9,7 @@ import {
 import React, { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
+import { useGoogleAnalytics } from 'volto-google-analytics';
 import Navigation from '../Navigation/Navigation';
 import { Masthead } from './Masthead';
 
@@ -73,6 +74,7 @@ const Header = ({ nswDesignSystem }) => {
         new nswDesignSystem['SiteSearch'](searchInputElement.current).init();
       });
   }, [searchInputElement]);
+  useGoogleAnalytics();
 
   //   TODO: We should be able to use a fragment instead of a div here. Not sure why the `Navigation` component isn't being rendered if we use a fragment.
   return (


### PR DESCRIPTION
This PR adds Google Analytics support through `volto-google-analytics`. It will be enabled if the `RAZZLE_GA_CODE` or `RAZZLE_GA4_CODE` environment variables are available.