### PR TITLE
Section schema

### DIFF
--- a/src/components/Blocks/Section/Edit.jsx
+++ b/src/components/Blocks/Section/Edit.jsx
@@ -167,7 +167,6 @@ const SubblockEdit = ({
             ? `data:${data.image['content-type']};base64,${data.image.data}`
             : null
         }
-        showSeparator={data.showSeparator}
       >
         <>
           {data.block && blockHasValue(data?.block.blocks[childBlockId]) ? (

--- a/src/components/Blocks/Section/Edit.jsx
+++ b/src/components/Blocks/Section/Edit.jsx
@@ -217,7 +217,7 @@ const SubblockEdit = ({
 
       <SidebarPortal selected={selected && selectedBlock === sectionBlockId}>
         <BlockDataForm
-          schema={schema({ intl })}
+          schema={schema({ intl, formData: data })}
           title="Section block"
           onChangeField={(id, value) => {
             onChangeBlock(sectionBlockId, {

--- a/src/components/Blocks/Section/Edit.jsx
+++ b/src/components/Blocks/Section/Edit.jsx
@@ -159,7 +159,7 @@ const SubblockEdit = ({
         title={data.title}
         description={data.description}
         padding={data.spacing}
-        isBox={data.box}
+        isBox={data.sectionType === 'box'}
         colour={data.colour}
         shouldInvert={data.invert}
         imageSrc={

--- a/src/components/Blocks/Section/View.jsx
+++ b/src/components/Blocks/Section/View.jsx
@@ -17,7 +17,7 @@ const SectionView = ({ data, isEditMode, ...props }) => {
       title={data.title}
       description={data.description}
       padding={data.sectionspacing}
-      isBox={data.sectionbox}
+      isBox={data.sectionType === 'box'}
       colour={colour}
       shouldInvert={data.sectioninvert}
       imageSrc={imageSrc}

--- a/src/components/Blocks/Section/View.jsx
+++ b/src/components/Blocks/Section/View.jsx
@@ -21,7 +21,6 @@ const SectionView = ({ data, isEditMode, ...props }) => {
       colour={colour}
       shouldInvert={data.sectioninvert}
       imageSrc={imageSrc}
-      showSeparator={data.sectionshowSeparator}
     >
       <RenderBlocks {...props} metadata={metadata} content={data.block} />
     </Section>

--- a/src/components/Blocks/Section/View.jsx
+++ b/src/components/Blocks/Section/View.jsx
@@ -1,6 +1,7 @@
 import { RenderBlocks } from '@plone/volto/components';
 import React from 'react';
 import { Section } from '../../Components/Section';
+import { getSectionColour } from './utils';
 
 // TODO: Support adding alt text to images
 const SectionView = ({ data, isEditMode, ...props }) => {
@@ -9,13 +10,15 @@ const SectionView = ({ data, isEditMode, ...props }) => {
     ? `data:${data.image['content-type']};base64,${data.sectionimage.data}`
     : null;
 
+  const colour = getSectionColour(data);
+
   return (
     <Section
       title={data.title}
       description={data.description}
       padding={data.sectionspacing}
       isBox={data.sectionbox}
-      colour={data.sectioncolour}
+      colour={colour}
       shouldInvert={data.sectioninvert}
       imageSrc={imageSrc}
       showSeparator={data.sectionshowSeparator}

--- a/src/components/Blocks/Section/View.jsx
+++ b/src/components/Blocks/Section/View.jsx
@@ -5,20 +5,20 @@ import { Section } from '../../Components/Section';
 // TODO: Support adding alt text to images
 const SectionView = ({ data, isEditMode, ...props }) => {
   const metadata = props.metadata || props.properties;
-  const imageSrc = data.image
-    ? `data:${data.image['content-type']};base64,${data.image.data}`
+  const imageSrc = data.sectionimage
+    ? `data:${data.image['content-type']};base64,${data.sectionimage.data}`
     : null;
 
   return (
     <Section
       title={data.title}
       description={data.description}
-      padding={data.spacing}
-      isBox={data.box}
-      colour={data.colour}
-      shouldInvert={data.invert}
+      padding={data.sectionspacing}
+      isBox={data.sectionbox}
+      colour={data.sectioncolour}
+      shouldInvert={data.sectioninvert}
       imageSrc={imageSrc}
-      showSeparator={data.showSeparator}
+      showSeparator={data.sectionshowSeparator}
     >
       <RenderBlocks {...props} metadata={metadata} content={data.block} />
     </Section>

--- a/src/components/Blocks/Section/index.js
+++ b/src/components/Blocks/Section/index.js
@@ -1,5 +1,5 @@
 import SectionEdit from './Edit';
-import SectionSchema from './Schema';
+import SectionSchema from './schema';
 import SectionView from './View';
 
 export { SectionEdit, SectionView, SectionSchema };

--- a/src/components/Blocks/Section/index.js
+++ b/src/components/Blocks/Section/index.js
@@ -1,4 +1,5 @@
 import SectionEdit from './Edit';
+import SectionSchema from './Schema';
 import SectionView from './View';
 
-export { SectionEdit, SectionView };
+export { SectionEdit, SectionView, SectionSchema };

--- a/src/components/Blocks/Section/schema.js
+++ b/src/components/Blocks/Section/schema.js
@@ -118,7 +118,7 @@ export const sectionSchema = ({ intl, formData }) => {
           ['colour-brand-light', 'Light'],
           ['colour-brand-dark', 'Dark'],
           ['colour-brand-supplementary', 'Supplementary'],
-          ['colour-brand-black', 'Black'],
+          ['colour-black', 'Black'],
           ['colour-white', 'White'],
           ['colour-off-white', 'Off White'],
           ['colour-grey-01', 'Grey 01'],

--- a/src/components/Blocks/Section/schema.js
+++ b/src/components/Blocks/Section/schema.js
@@ -69,12 +69,7 @@ const messages = defineMessages({
 });
 
 const sectionTypeFieldsMapping = {
-  sameAsPrevious: [
-    'sectioninvert',
-    'sectionspacing',
-    'sectionbox',
-    'sectionshowSeparator',
-  ],
+  sameAsPrevious: [],
   colour: [
     'sectioninvert',
     'sectionspacing',
@@ -98,7 +93,6 @@ export const sectionSchema = ({ intl, formData }) => {
   }
 
   return {
-    required: ['spacing', 'box', 'colour', 'invert'],
     fieldsets: [
       {
         id: 'default',
@@ -112,6 +106,7 @@ export const sectionSchema = ({ intl, formData }) => {
         required: ['sectionType'],
       },
     ],
+    required: ['sectionType'],
     properties: {
       sectionType: {
         title: intl.formatMessage(messages.sectionTypeTitle),
@@ -132,8 +127,7 @@ export const sectionSchema = ({ intl, formData }) => {
           ['colour-grey-04', 'Grey 04'],
           ['image', 'Image'],
         ],
-        placeholder: 'temporary',
-        // default: 'full',
+        default: '',
       },
       title: {
         title: intl.formatMessage(messages.sectionTitleTitle),
@@ -153,7 +147,7 @@ export const sectionSchema = ({ intl, formData }) => {
           ['half', 'Half spacing'],
           ['no', 'No spacing'],
         ],
-        // default: 'full',
+        placeholder: 'Full spacing',
       },
       sectionimage: {
         title: intl.formatMessage(messages.imageTitle),

--- a/src/components/Blocks/Section/schema.js
+++ b/src/components/Blocks/Section/schema.js
@@ -98,7 +98,7 @@ export const sectionSchema = ({ intl }) => {
           ['half', 'Half spacing'],
           ['no', 'No spacing'],
         ],
-        default: 'full',
+        // default: 'full',
       },
       sectionimage: {
         title: intl.formatMessage(messages.imageTitle),
@@ -109,7 +109,7 @@ export const sectionSchema = ({ intl }) => {
         title: intl.formatMessage(messages.boxTitle),
         description: intl.formatMessage(messages.boxDescription),
         type: 'boolean',
-        default: false,
+        // default: false,
       },
       sectioncolour: {
         title: intl.formatMessage(messages.colourTitle),
@@ -127,19 +127,19 @@ export const sectionSchema = ({ intl }) => {
           ['grey-03', 'Grey 03'],
           ['grey-04', 'Grey 04'],
         ],
-        default: 'brand-light',
+        // default: 'brand-light',
       },
       sectioninvert: {
         title: intl.formatMessage(messages.invertTitle),
         description: intl.formatMessage(messages.invertDescription),
         type: 'boolean',
-        default: false,
+        // default: false,
       },
       sectionshowSeparator: {
         title: intl.formatMessage(messages.showSeparatorTitle),
         description: intl.formatMessage(messages.showSeparatorTitleDescription),
         type: 'boolean',
-        default: false,
+        // default: false,
       },
     },
   };

--- a/src/components/Blocks/Section/schema.js
+++ b/src/components/Blocks/Section/schema.js
@@ -73,14 +73,20 @@ const sectionTypeFieldsMapping = {
   colour: [
     'sectioninvert',
     'sectionspacing',
-    'sectionbox',
+    // 'sectionbox',
     'sectionshowSeparator',
   ],
   image: [
     'sectionimage',
     'sectioninvert',
     'sectionspacing',
-    'sectionbox',
+    // 'sectionbox',
+    'sectionshowSeparator',
+  ],
+  box: [
+    'sectioninvert',
+    'sectionspacing',
+    // 'sectionbox',
     'sectionshowSeparator',
   ],
 };
@@ -126,6 +132,7 @@ export const sectionSchema = ({ intl, formData }) => {
           ['colour-grey-03', 'Grey 03'],
           ['colour-grey-04', 'Grey 04'],
           ['image', 'Image'],
+          ['box', 'Box'],
         ],
         default: '',
       },
@@ -154,12 +161,12 @@ export const sectionSchema = ({ intl, formData }) => {
         type: 'file',
         widget: 'file',
       },
-      sectionbox: {
-        title: intl.formatMessage(messages.boxTitle),
-        description: intl.formatMessage(messages.boxDescription),
-        type: 'boolean',
-        // default: false,
-      },
+      // sectionbox: {
+      //   title: intl.formatMessage(messages.boxTitle),
+      //   description: intl.formatMessage(messages.boxDescription),
+      //   type: 'boolean',
+      //   // default: false,
+      // },
       sectioncolour: {
         title: intl.formatMessage(messages.colourTitle),
         type: 'string',

--- a/src/components/Blocks/Section/schema.js
+++ b/src/components/Blocks/Section/schema.js
@@ -28,15 +28,6 @@ const messages = defineMessages({
     id: 'Schema_Image_Title',
     defaultMessage: 'Image',
   },
-  boxTitle: {
-    id: 'Schema_Box_Title',
-    defaultMessage: 'Display as box?',
-  },
-  boxDescription: {
-    id: 'Schema_Box_Description',
-    defaultMessage:
-      'A box section will have rounded corners and a thin grey outline',
-  },
   colourTitle: {
     id: 'Schema_Colour_Title',
     defaultMessage: 'Colour',
@@ -45,37 +36,13 @@ const messages = defineMessages({
     id: 'Schema_Invert_Title',
     defaultMessage: 'Display with inverted text?',
   },
-  showSeparatorTitle: {
-    id: 'Schema_ShowSeparator_Title',
-    defaultMessage: 'Show separator?',
-  },
-  showSeparatorTitleDescription: {
-    id: 'Schema_ShowSeparator_Description',
-    defaultMessage: 'Enabling shows a horizontal separator after the section.',
-  },
 });
 
 const sectionTypeFieldsMapping = {
   sameAsPrevious: [],
-  colour: [
-    'sectioninvert',
-    'sectionspacing',
-    // 'sectionbox',
-    'sectionshowSeparator',
-  ],
-  image: [
-    'sectionimage',
-    'sectioninvert',
-    'sectionspacing',
-    // 'sectionbox',
-    'sectionshowSeparator',
-  ],
-  box: [
-    'sectioninvert',
-    'sectionspacing',
-    // 'sectionbox',
-    'sectionshowSeparator',
-  ],
+  colour: ['sectioninvert', 'sectionspacing'],
+  image: ['sectionimage', 'sectioninvert', 'sectionspacing'],
+  box: ['sectioninvert', 'sectionspacing'],
 };
 
 export const sectionSchema = ({ intl, formData }) => {
@@ -148,12 +115,6 @@ export const sectionSchema = ({ intl, formData }) => {
         type: 'file',
         widget: 'file',
       },
-      // sectionbox: {
-      //   title: intl.formatMessage(messages.boxTitle),
-      //   description: intl.formatMessage(messages.boxDescription),
-      //   type: 'boolean',
-      //   // default: false,
-      // },
       sectioncolour: {
         title: intl.formatMessage(messages.colourTitle),
         type: 'string',
@@ -170,18 +131,10 @@ export const sectionSchema = ({ intl, formData }) => {
           ['grey-03', 'Grey 03'],
           ['grey-04', 'Grey 04'],
         ],
-        // default: 'brand-light',
       },
       sectioninvert: {
         title: intl.formatMessage(messages.invertTitle),
         type: 'boolean',
-        // default: false,
-      },
-      sectionshowSeparator: {
-        title: intl.formatMessage(messages.showSeparatorTitle),
-        description: intl.formatMessage(messages.showSeparatorTitleDescription),
-        type: 'boolean',
-        // default: false,
       },
     },
   };

--- a/src/components/Blocks/Section/schema.js
+++ b/src/components/Blocks/Section/schema.js
@@ -8,6 +8,14 @@ const messages = defineMessages({
     id: 'Schema_Description_Title',
     defaultMessage: 'Description',
   },
+  sectionTypeTitle: {
+    id: 'Schema_SectionType_Title',
+    defaultMessage: 'Section type',
+  },
+  sectionTypeDescription: {
+    id: 'Schema_SectionType_Description',
+    defaultMessage: '',
+  },
   spacingTitle: {
     id: 'Schema_Spacing_Title',
     defaultMessage: 'Spacing',
@@ -60,7 +68,35 @@ const messages = defineMessages({
   },
 });
 
-export const sectionSchema = ({ intl }) => {
+const sectionTypeFieldsMapping = {
+  sameAsPrevious: [
+    'sectioninvert',
+    'sectionspacing',
+    'sectionbox',
+    'sectionshowSeparator',
+  ],
+  colour: [
+    'sectioninvert',
+    'sectionspacing',
+    'sectionbox',
+    'sectionshowSeparator',
+  ],
+  image: [
+    'sectionimage',
+    'sectioninvert',
+    'sectionspacing',
+    'sectionbox',
+    'sectionshowSeparator',
+  ],
+};
+
+export const sectionSchema = ({ intl, formData }) => {
+  let sectionType = formData && formData.sectionType;
+
+  if (sectionType && sectionType.startsWith('colour-')) {
+    sectionType = 'colour';
+  }
+
   return {
     required: ['spacing', 'box', 'colour', 'invert'],
     fieldsets: [
@@ -68,18 +104,37 @@ export const sectionSchema = ({ intl }) => {
         id: 'default',
         title: 'Default',
         fields: [
-          // 'title',
-          // 'description',
-          'sectionspacing',
-          'sectionimage',
-          'sectionbox',
-          'sectioncolour',
-          'sectioninvert',
-          'sectionshowSeparator',
+          'title',
+          'description',
+          'sectionType',
+          ...(sectionTypeFieldsMapping[sectionType] ?? []),
         ],
+        required: ['sectionType'],
       },
     ],
     properties: {
+      sectionType: {
+        title: intl.formatMessage(messages.sectionTypeTitle),
+        type: 'string',
+        factory: 'Choice',
+        choices: [
+          ['', 'No section'],
+          ['sameAsPrevious', 'Same as previous'],
+          ['colour-brand-light', 'Light'],
+          ['colour-brand-dark', 'Dark'],
+          ['colour-brand-supplementary', 'Supplementary'],
+          ['colour-brand-black', 'Black'],
+          ['colour-white', 'White'],
+          ['colour-off-white', 'Off White'],
+          ['colour-grey-01', 'Grey 01'],
+          ['colour-grey-02', 'Grey 02'],
+          ['colour-grey-03', 'Grey 03'],
+          ['colour-grey-04', 'Grey 04'],
+          ['image', 'Image'],
+        ],
+        placeholder: 'temporary',
+        // default: 'full',
+      },
       title: {
         title: intl.formatMessage(messages.sectionTitleTitle),
         type: 'string',

--- a/src/components/Blocks/Section/schema.js
+++ b/src/components/Blocks/Section/schema.js
@@ -28,10 +28,6 @@ const messages = defineMessages({
     id: 'Schema_Image_Title',
     defaultMessage: 'Image',
   },
-  // imageDescription: {
-  //   id: 'Schema_Image_Description',
-  //   defaultMessage: 'Image',
-  // },
   boxTitle: {
     id: 'Schema_Box_Title',
     defaultMessage: 'Display as box?',
@@ -45,18 +41,9 @@ const messages = defineMessages({
     id: 'Schema_Colour_Title',
     defaultMessage: 'Colour',
   },
-  // colourDescription: {
-  //   id: 'Schema_Colour_Description',
-  //   defaultMessage: 'Colour',
-  // },
   invertTitle: {
     id: 'Schema_Invert_Title',
-    defaultMessage: 'Invert support?',
-  },
-  invertDescription: {
-    id: 'Schema_Invert_Description',
-    defaultMessage:
-      'Enable if you want to use components and links inside the sections with dark background',
+    defaultMessage: 'Display with inverted text?',
   },
   showSeparatorTitle: {
     id: 'Schema_ShowSeparator_Title',
@@ -187,7 +174,6 @@ export const sectionSchema = ({ intl, formData }) => {
       },
       sectioninvert: {
         title: intl.formatMessage(messages.invertTitle),
-        description: intl.formatMessage(messages.invertDescription),
         type: 'boolean',
         // default: false,
       },

--- a/src/components/Blocks/Section/schema.js
+++ b/src/components/Blocks/Section/schema.js
@@ -68,14 +68,14 @@ export const sectionSchema = ({ intl }) => {
         id: 'default',
         title: 'Default',
         fields: [
-          'title',
-          'description',
-          'spacing',
-          'image',
-          'box',
-          'colour',
-          'invert',
-          'showSeparator',
+          // 'title',
+          // 'description',
+          'sectionspacing',
+          'sectionimage',
+          'sectionbox',
+          'sectioncolour',
+          'sectioninvert',
+          'sectionshowSeparator',
         ],
       },
     ],
@@ -88,7 +88,7 @@ export const sectionSchema = ({ intl }) => {
         title: intl.formatMessage(messages.sectionDescriptionTitle),
         type: 'string',
       },
-      spacing: {
+      sectionspacing: {
         title: intl.formatMessage(messages.spacingTitle),
         description: intl.formatMessage(messages.spacingDescription),
         type: 'string',
@@ -100,18 +100,18 @@ export const sectionSchema = ({ intl }) => {
         ],
         default: 'full',
       },
-      image: {
+      sectionimage: {
         title: intl.formatMessage(messages.imageTitle),
         type: 'file',
         widget: 'file',
       },
-      box: {
+      sectionbox: {
         title: intl.formatMessage(messages.boxTitle),
         description: intl.formatMessage(messages.boxDescription),
         type: 'boolean',
         default: false,
       },
-      colour: {
+      sectioncolour: {
         title: intl.formatMessage(messages.colourTitle),
         type: 'string',
         factory: 'Choice',
@@ -129,13 +129,13 @@ export const sectionSchema = ({ intl }) => {
         ],
         default: 'brand-light',
       },
-      invert: {
+      sectioninvert: {
         title: intl.formatMessage(messages.invertTitle),
         description: intl.formatMessage(messages.invertDescription),
         type: 'boolean',
         default: false,
       },
-      showSeparator: {
+      sectionshowSeparator: {
         title: intl.formatMessage(messages.showSeparatorTitle),
         description: intl.formatMessage(messages.showSeparatorTitleDescription),
         type: 'boolean',

--- a/src/components/Blocks/Section/utils.js
+++ b/src/components/Blocks/Section/utils.js
@@ -1,0 +1,8 @@
+export function getSectionColour(data) {
+  // TODO: Remove backwards compatibility with section blocks
+  let colour = data.colour;
+  if (data.sectionType && data.sectionType.startsWith('colour-')) {
+    colour = data.sectionType.replace('colour-', '');
+  }
+  return colour;
+}

--- a/src/components/Blocks/Separator/Edit.jsx
+++ b/src/components/Blocks/Separator/Edit.jsx
@@ -1,0 +1,50 @@
+import { BlockDataForm, SidebarPortal } from '@plone/volto/components';
+import React from 'react';
+import { separatorSchema } from './schema';
+
+function SeparatorEditDisplay() {
+  return (
+    <hr
+      style={{ margin: 0, minWidth: '65vw' }}
+      className="nsw-section-separator"
+    />
+  );
+}
+
+function SeparatorData(props) {
+  const { data, block, onChangeBlock } = props;
+  const schema = separatorSchema({ ...props });
+  return (
+    <BlockDataForm
+      schema={schema}
+      title="Separator"
+      onChangeField={(id, value) => {
+        onChangeBlock(block, {
+          ...data,
+          [id]: value,
+        });
+      }}
+      formData={data}
+      block={block}
+    />
+  );
+}
+
+export function SeparatorEdit(props) {
+  const { data, onChangeBlock, block, selected } = props;
+  return (
+    <>
+      <SeparatorEditDisplay data={data} id={block} isEditMode />
+      <SidebarPortal selected={selected}>
+        <SeparatorData
+          title={'Separator'}
+          key={block}
+          data={data}
+          block={block}
+          onChangeBlock={onChangeBlock}
+          {...props}
+        />
+      </SidebarPortal>
+    </>
+  );
+}

--- a/src/components/Blocks/Separator/View.jsx
+++ b/src/components/Blocks/Separator/View.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export function SeparatorView() {
+  return <hr className="nsw-section-separator" />;
+}

--- a/src/components/Blocks/Separator/index.js
+++ b/src/components/Blocks/Separator/index.js
@@ -1,0 +1,3 @@
+export { SeparatorEdit } from './Edit';
+export { separatorSchema } from './schema';
+export { SeparatorView } from './View';

--- a/src/components/Blocks/Separator/schema.js
+++ b/src/components/Blocks/Separator/schema.js
@@ -1,0 +1,14 @@
+export function separatorSchema() {
+  return {
+    fieldsets: [
+      {
+        id: 'default',
+        title: 'Default',
+        fields: [],
+        required: [],
+      },
+    ],
+    required: [],
+    properties: {},
+  };
+}

--- a/src/components/Components/Section.jsx
+++ b/src/components/Components/Section.jsx
@@ -11,30 +11,24 @@ const Section = ({
   colour,
   shouldInvert,
   imageSrc = undefined,
-  showSeparator = false,
 }) => {
   return (
-    <>
-      <section
-        className={cx('nsw-section', {
-          [`nsw-section--${padding}-padding`]: padding && padding !== 'full',
-          'nsw-section--box': isBox,
-          [`nsw-section--${colour}`]: colour,
-          'nsw-section--invert': shouldInvert,
-          'nsw-section--image': imageSrc,
-        })}
-        style={imageSrc ? { backgroundImage: `url(${imageSrc})` } : null}
-      >
-        <div className="nsw-container">
-          {title ? <h2 className="nsw-section-title">{title}</h2> : null}
-          {description ? (
-            <p className="nsw-section-text">{description}</p>
-          ) : null}
-          {children}
-        </div>
-      </section>
-      {showSeparator ? <hr className="nsw-section-separator" /> : null}
-    </>
+    <section
+      className={cx('nsw-section', {
+        [`nsw-section--${padding}-padding`]: padding && padding !== 'full',
+        'nsw-section--box': isBox,
+        [`nsw-section--${colour}`]: colour,
+        'nsw-section--invert': shouldInvert,
+        'nsw-section--image': imageSrc,
+      })}
+      style={imageSrc ? { backgroundImage: `url(${imageSrc})` } : null}
+    >
+      <div className="nsw-container">
+        {title ? <h2 className="nsw-section-title">{title}</h2> : null}
+        {description ? <p className="nsw-section-text">{description}</p> : null}
+        {children}
+      </div>
+    </section>
   );
 };
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -23,4 +23,9 @@ export {
 export { InPageAlertEdit, InPageAlertView } from './Blocks/InPageAlert';
 export { LinkListEdit, LinkListView } from './Blocks/LinkList';
 export { SectionEdit, SectionSchema, SectionView } from './Blocks/Section';
+export {
+  SeparatorEdit,
+  separatorSchema,
+  SeparatorView,
+} from './Blocks/Separator';
 export { SidebarEdit, SidebarView } from './Blocks/Sidebar';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -22,5 +22,5 @@ export {
 } from './Blocks/DropdownQuickNavigation';
 export { InPageAlertEdit, InPageAlertView } from './Blocks/InPageAlert';
 export { LinkListEdit, LinkListView } from './Blocks/LinkList';
-export { SectionEdit, SectionView } from './Blocks/Section';
+export { SectionEdit, SectionSchema, SectionView } from './Blocks/Section';
 export { SidebarEdit, SidebarView } from './Blocks/Sidebar';

--- a/src/config/blocks.js
+++ b/src/config/blocks.js
@@ -481,6 +481,7 @@ function removeVariationsFromBlock(config, blockId, variationsToRemove) {
 function withSectionSchema({ schema, formData, intl }) {
   const sectionSchema = SectionSchema({
     intl,
+    formData,
   });
   schema.properties = {
     ...schema.properties,
@@ -492,7 +493,11 @@ function withSectionSchema({ schema, formData, intl }) {
   const sectionFieldset = {
     id: 'sectionFieldset',
     title: 'Section',
-    fields: [...sectionSchema.fieldsets[0].fields],
+    fields: [
+      ...sectionSchema.fieldsets[defaultFieldsetIndex].fields.filter(
+        (fieldId) => !['title', 'description'].includes(fieldId),
+      ),
+    ],
   };
   schema.fieldsets = [...schema.fieldsets, sectionFieldset];
   return schema;
@@ -557,6 +562,9 @@ export const updateBlocksConfig = (config) => {
     });
   });
   Object.keys(config.blocks.blocksConfig).forEach((blockId) => {
+    if (blockId === 'nsw_section') {
+      return;
+    }
     config.blocks.blocksConfig[blockId].schemaEnhancer = composeSchema(
       config.blocks.blocksConfig[blockId].schemaEnhancer,
       withSectionSchema,

--- a/src/config/blocks.js
+++ b/src/config/blocks.js
@@ -1,3 +1,4 @@
+import { composeSchema } from '@plone/volto/helpers';
 import sliderSVG from '@plone/volto/icons/slider.svg';
 import { defineMessages } from 'react-intl';
 // Todo: Setup path imports for blocks
@@ -10,6 +11,7 @@ import * as Components from '../components';
 import { CardSchema } from '../components/Blocks/Card';
 import { DropdownQuickNavigationSchema } from '../components/Blocks/DropdownQuickNavigation/schema';
 import CardListing from '../components/Blocks/Listing/CardListing';
+import { SectionSchema } from '../components/Blocks/Section';
 
 const messages = defineMessages({
   card: {
@@ -476,6 +478,26 @@ function removeVariationsFromBlock(config, blockId, variationsToRemove) {
   });
 }
 
+function withSectionSchema({ schema, formData, intl }) {
+  const sectionSchema = SectionSchema({
+    intl,
+  });
+  schema.properties = {
+    ...schema.properties,
+    ...sectionSchema.properties,
+  };
+  const defaultFieldsetIndex = schema.fieldsets.findIndex(
+    (fieldset) => fieldset.id === 'default',
+  );
+  const sectionFieldset = {
+    id: 'sectionFieldset',
+    title: 'Section',
+    fields: [...sectionSchema.fieldsets[0].fields],
+  };
+  schema.fieldsets = [...schema.fieldsets, sectionFieldset];
+  return schema;
+}
+
 export const updateBlocksConfig = (config) => {
   // Add 'NSW' group
   config.blocks.groupBlocksOrder = [
@@ -533,6 +555,12 @@ export const updateBlocksConfig = (config) => {
         variationIndex
       ].schemaEnhancer = schemaEnhancer;
     });
+  });
+  Object.keys(config.blocks.blocksConfig).forEach((blockId) => {
+    config.blocks.blocksConfig[blockId].schemaEnhancer = composeSchema(
+      config.blocks.blocksConfig[blockId].schemaEnhancer,
+      withSectionSchema,
+    );
   });
 
   // Remove requirement for titles

--- a/src/config/blocks.js
+++ b/src/config/blocks.js
@@ -185,6 +185,15 @@ const nswBlocks = [
     },
   },
   {
+    id: 'separator',
+    title: 'Separator',
+    icon: sliderSVG,
+    group: 'nsw',
+    view: Components.SeparatorView,
+    edit: Components.SeparatorEdit,
+    restricted: false,
+  },
+  {
     id: 'nsw_sidebar',
     title: 'Sidebar',
     icon: sliderSVG,

--- a/src/customizations/volto/components/theme/View/DefaultView.jsx
+++ b/src/customizations/volto/components/theme/View/DefaultView.jsx
@@ -176,7 +176,7 @@ const BlocksLayout = ({ content, location }) => {
                   <Section
                     key={index}
                     padding={blockWithSectionData.sectionspacing}
-                    isBox={blockWithSectionData.sectionbox}
+                    isBox={blockWithSectionData.sectionType === 'box'}
                     colour={sectionColour}
                     shouldInvert={blockWithSectionData.sectioninvert}
                     showSeparator={blockWithSectionData.sectionshowSeparator}

--- a/src/customizations/volto/components/theme/View/DefaultView.jsx
+++ b/src/customizations/volto/components/theme/View/DefaultView.jsx
@@ -196,25 +196,13 @@ const BlocksLayout = ({ content, location }) => {
                       config.blocks.blocksConfig[blockType]?.['view'] || null;
                     // debugger;
                     return Block !== null ? (
-                      <div className="nsw-section">
-                        <Section
-                          // title={blockData.title}
-                          // description={blockData.description}
-                          padding={blockData.sectionspacing}
-                          isBox={blockData.sectionbox}
-                          colour={blockData.sectioncolour}
-                          shouldInvert={blockData.sectioninvert}
-                          showSeparator={blockData.sectionshowSeparator}
-                        >
-                          <Block
-                            key={blockId}
-                            id={blockId}
-                            properties={content}
-                            data={blocksData[blockId]}
-                            path={getBaseUrl(location?.pathname || '')}
-                          />
-                        </Section>
-                      </div>
+                      <Block
+                        key={blockId}
+                        id={blockId}
+                        properties={content}
+                        data={blocksData[blockId]}
+                        path={getBaseUrl(location?.pathname || '')}
+                      />
                     ) : (
                       <div key={blockId}>
                         {intl.formatMessage(messages.unknownBlock, {

--- a/src/customizations/volto/components/theme/View/DefaultView.jsx
+++ b/src/customizations/volto/components/theme/View/DefaultView.jsx
@@ -175,6 +175,7 @@ const BlocksLayout = ({ content, location }) => {
                 // debugger;
                 return (
                   <Section
+                    key={index}
                     // title={blockData.title}
                     // description={blockData.description}
                     padding={blockWithSectionData.sectionspacing}

--- a/src/customizations/volto/components/theme/View/DefaultView.jsx
+++ b/src/customizations/volto/components/theme/View/DefaultView.jsx
@@ -142,7 +142,16 @@ const BlocksLayout = ({ content, location }) => {
   return (
     <div id="page-document">
       <div className="nsw-layout">
-        <div className="nsw-layout__main">
+        <div
+          className="nsw-layout__main"
+          style={
+            fullWidthBlockTypes.includes(
+              blocksData[blocksInLayout[0]]?.['@type'],
+            )
+              ? { paddingBlockStart: '0' }
+              : null
+          }
+        >
           {groupedBlocksLayout.map((blockIdOrGroup, index) => {
             if (blockIdOrGroup instanceof Array) {
               const blockGroup = blockIdOrGroup; // Rename it just to make the code more readable

--- a/src/customizations/volto/components/theme/View/DefaultView.jsx
+++ b/src/customizations/volto/components/theme/View/DefaultView.jsx
@@ -42,10 +42,8 @@ const sectionFields = [
   'sectionType',
   'sectionspacing',
   'sectionimage',
-  'sectionbox',
   'sectioncolour',
   'sectioninvert',
-  'sectionshowSeparator',
 ];
 
 const getCoreContentGroupedLayout = (blocksInLayout, blocksData) => {
@@ -179,7 +177,6 @@ const BlocksLayout = ({ content, location }) => {
                     isBox={blockWithSectionData.sectionType === 'box'}
                     colour={sectionColour}
                     shouldInvert={blockWithSectionData.sectioninvert}
-                    showSeparator={blockWithSectionData.sectionshowSeparator}
                   >
                     {blockGroup.map((blockId) => {
                       // Copy pasted from below. Should really make this a function!

--- a/src/customizations/volto/components/theme/View/DefaultView.jsx
+++ b/src/customizations/volto/components/theme/View/DefaultView.jsx
@@ -7,6 +7,7 @@ import {
 } from '@plone/volto/helpers';
 import config from '@plone/volto/registry';
 import cx from 'classnames';
+import { getSectionColour } from 'nsw-design-system-plone6/components/Blocks/Section/utils';
 import { Section } from 'nsw-design-system-plone6/components/Components/Section';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -38,6 +39,7 @@ const coreContentBlockTypes = [
 ];
 
 const sectionFields = [
+  'sectionType',
   'sectionspacing',
   'sectionimage',
   'sectionbox',
@@ -82,8 +84,9 @@ const getCoreContentGroupedLayout = (blocksInLayout, blocksData) => {
         );
 
         if (
+          currentBlockSectionData.sectionType === 'sameAsPrevious' ||
           JSON.stringify(previousBlockSectionData) ===
-          JSON.stringify(currentBlockSectionData)
+            JSON.stringify(currentBlockSectionData)
         ) {
           previousBlockOrGroup.push(currentBlockId);
           result.splice(result.length - 1, 1, previousBlockOrGroup);
@@ -157,6 +160,7 @@ const BlocksLayout = ({ content, location }) => {
               const blockGroup = blockIdOrGroup; // Rename it just to make the code more readable
               if (_blockNeedsSection(blocksData?.[blockGroup[0]])) {
                 const blockWithSectionData = blocksData?.[blockGroup[0]];
+                const sectionColour = getSectionColour(blockWithSectionData);
                 // debugger;
                 return (
                   <Section
@@ -164,7 +168,7 @@ const BlocksLayout = ({ content, location }) => {
                     // description={blockData.description}
                     padding={blockWithSectionData.sectionspacing}
                     isBox={blockWithSectionData.sectionbox}
-                    colour={blockWithSectionData.sectioncolour}
+                    colour={sectionColour}
                     shouldInvert={blockWithSectionData.sectioninvert}
                     showSeparator={blockWithSectionData.sectionshowSeparator}
                   >

--- a/src/customizations/volto/components/theme/View/DefaultView.jsx
+++ b/src/customizations/volto/components/theme/View/DefaultView.jsx
@@ -176,8 +176,6 @@ const BlocksLayout = ({ content, location }) => {
                 return (
                   <Section
                     key={index}
-                    // title={blockData.title}
-                    // description={blockData.description}
                     padding={blockWithSectionData.sectionspacing}
                     isBox={blockWithSectionData.sectionbox}
                     colour={sectionColour}

--- a/src/customizations/volto/components/theme/View/DefaultView.jsx
+++ b/src/customizations/volto/components/theme/View/DefaultView.jsx
@@ -66,16 +66,16 @@ const getCoreContentGroupedLayout = (blocksInLayout, blocksData) => {
     const currentBlock = blocksData[currentBlockId];
     const currentBlockType = currentBlock['@type'];
     const previousBlockOrGroup = result[result.length - 1];
+    const previousBlock =
+      previousBlockOrGroup instanceof Array
+        ? blocksData[previousBlockOrGroup[previousBlockOrGroup.length - 1]]
+        : blocksData[previousBlockOrGroup];
 
     if (_blockNeedsSection(currentBlock)) {
       // Make sure we have another block
       if (previousBlockOrGroup) {
-        const previousBlock =
-          previousBlockOrGroup instanceof Array
-            ? previousBlockOrGroup[previousBlockOrGroup.length - 1]
-            : previousBlockOrGroup;
         const previousBlockSectionData = Object.fromEntries(
-          sectionFields.map((k) => [k, blocksData[previousBlock]?.[k]]),
+          sectionFields.map((k) => [k, previousBlock?.[k]]),
         );
         const currentBlockSectionData = Object.fromEntries(
           sectionFields.map((k) => [k, currentBlock?.[k]]),
@@ -93,10 +93,14 @@ const getCoreContentGroupedLayout = (blocksInLayout, blocksData) => {
       } else {
         result.push([currentBlockId]);
       }
+      return result;
     }
+
     // If the previous block is a group and the current block is a core content block,
     // add the current block to the group.
-    else if (
+    if (previousBlock && _blockNeedsSection(previousBlock)) {
+      result.push([currentBlockId]);
+    } else if (
       previousBlockOrGroup instanceof Array &&
       coreContentBlockTypes.includes(currentBlockType)
     ) {

--- a/src/customizations/volto/components/theme/View/DefaultView.jsx
+++ b/src/customizations/volto/components/theme/View/DefaultView.jsx
@@ -125,6 +125,17 @@ const getCoreContentGroupedLayout = (blocksInLayout, blocksData) => {
 };
 
 function _blockNeedsSection(blockData) {
+  // We don't want to double up on sections.
+  if (blockData['@type'] === 'nsw_section') {
+    return false;
+  }
+  if (blockData.sectionType) {
+    return true;
+  }
+  // The value is an empty string if we had a value in the past but set it back to no section
+  if (blockData.sectionType === '') {
+    return false;
+  }
   if (Object.keys(blockData).some((r) => sectionFields.includes(r))) {
     return true;
   }

--- a/src/customizations/volto/components/theme/View/DefaultView.jsx
+++ b/src/customizations/volto/components/theme/View/DefaultView.jsx
@@ -172,7 +172,6 @@ const BlocksLayout = ({ content, location }) => {
               if (_blockNeedsSection(blocksData?.[blockGroup[0]])) {
                 const blockWithSectionData = blocksData?.[blockGroup[0]];
                 const sectionColour = getSectionColour(blockWithSectionData);
-                // debugger;
                 return (
                   <Section
                     key={index}
@@ -188,7 +187,6 @@ const BlocksLayout = ({ content, location }) => {
                       const blockType = blockData?.['@type'];
                       const Block =
                         config.blocks.blocksConfig[blockType]?.['view'] || null;
-                      // debugger;
                       return Block !== null ? (
                         <Block
                           key={blockId}
@@ -221,7 +219,6 @@ const BlocksLayout = ({ content, location }) => {
                     const blockType = blockData?.['@type'];
                     const Block =
                       config.blocks.blocksConfig[blockType]?.['view'] || null;
-                    // debugger;
                     return Block !== null ? (
                       <Block
                         key={blockId}


### PR DESCRIPTION
This PR adds an additional way to add sections outside of the 'Section' block to speed up creation of large sections. Every block has an additional 'Section' schema added to it to wrap the block in a section when it is displayed on the page. The section schema has also  been adjust so that the colours, image and box options are all now in a single `Section type` field. Additionally, the `Show separator` option has been removed and replaced with a section block


Uploading Screen Recording 2022-11-17 at 6.04.09 pm.mov…

