### PR TITLE
Fix mobile navigation not closing on page change

### DIFF
--- a/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -168,6 +168,7 @@ const Navigation = () => {
       navigationController.current.openSubNavElements.length > 0
     ) {
       navigationController.current.closeSubNav();
+      navigationController.current.mobileHideMainNav({ propertyName: '' });
     }
   }, [location]);
   useEffect(() => {


### PR DESCRIPTION
This PR fixes the issue where pressing a page to navigate to from the mobile navigation menu will only close the sub-menu and not the main navigation menu, causing the screen to still be obscured even though the page transition happened in the background