### PR TITLE
SVG material-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@eeacms/volto-accordion-block": "6.0.0",
     "@fontsource/public-sans": "4.5.11",
     "@kitconcept/volto-blocks-grid": "5.1.1",
+    "@material-design-icons/svg": "0.14.1",
     "@mdi/svg": "7.0.96",
     "material-icons": "1.12.1",
     "nsw-design-system": "3.2.4",

--- a/razzle.extend.js
+++ b/razzle.extend.js
@@ -8,12 +8,32 @@ const modifyWebpackConfig = (config, { target, dev }, webpack) => {
   const fileLoader = config.module.rules.find(fileLoaderFinder);
   fileLoader.exclude = [
     /@mdi\/svg\/.*\.svg$/,
+    /@material-design-icons\/svg\/filled\.svg$/,
     /nsw-design-system-plone6\/.*\.svg$/,
     ...fileLoader.exclude,
   ];
 
   const MDISVGLOADER = {
     test: /@mdi\/svg\/.*\.svg$/,
+    use: [
+      {
+        loader: 'svg-loader',
+      },
+      {
+        loader: 'svgo-loader',
+        options: {
+          plugins: [
+            { removeTitle: true },
+            { convertPathData: false },
+            { removeUselessStrokeAndFill: true },
+            { removeViewBox: false },
+          ],
+        },
+      },
+    ],
+  };
+  const MATERIALICONSSVGLOADER = {
+    test: /@material-design-icons\/svg\/filled\.svg$/,
     use: [
       {
         loader: 'svg-loader',
@@ -52,6 +72,7 @@ const modifyWebpackConfig = (config, { target, dev }, webpack) => {
   };
 
   webpack.module.rules.push(MDISVGLOADER);
+  webpack.module.rules.push(MATERIALICONSSVGLOADER);
   webpack.module.rules.push(NSWSVGLOEADER);
 
   return config;

--- a/src/custom.less
+++ b/src/custom.less
@@ -1,0 +1,20 @@
+html {
+  font-size: 100% !important;
+}
+
+body.public-ui {
+  font-size: var(--nsw-font-size-sm-mobile);
+  line-height: var(--nsw-line-height-sm-mobile);
+  font-family: var(--nsw-font-family);
+  font-weight: var(--nsw-font-normal);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: var(--nsw-text-dark);
+
+  @media (min-width: 62rem) {
+    & {
+      font-size: var(--nsw-font-size-sm-desktop);
+      line-height: var(--nsw-line-height-sm-desktop);
+    }
+  }
+}

--- a/src/customizations/volto/components/manage/Blocks/Search/components/SearchInput.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/components/SearchInput.jsx
@@ -1,5 +1,8 @@
+import { Icon } from '@plone/volto/components';
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+
+import SearchSVG from '@material-design-icons/svg/filled/search.svg';
 
 const messages = defineMessages({
   search: {
@@ -52,13 +55,12 @@ const SearchInput = ({
             className="nsw-button nsw-button--white nsw-button--flex"
             type="submit"
           >
-            <span
+            <Icon
+              name={SearchSVG}
               className="material-icons nsw-material-icons"
-              focusable="false"
-              aria-hidden="true"
-            >
-              search
-            </span>
+              size="36px"
+              ariaHidden={true}
+            />
           </button>
         </div>
       </div>

--- a/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/src/customizations/volto/components/theme/Header/Header.jsx
@@ -15,6 +15,7 @@ import Navigation from '../Navigation/Navigation';
 import { Masthead } from './Masthead';
 
 import MenuSVG from '@material-design-icons/svg/filled/menu.svg';
+import SearchSVG from '@material-design-icons/svg/filled/search.svg';
 
 const MenuOpenButton = () => (
   <div className="nsw-header__menu">
@@ -47,13 +48,12 @@ const SearchStartButton = ({ searchInputElement }) => {
         aria-controls="header-search"
         ref={searchInputElement}
       >
-        <span
+        <Icon
+          name={SearchSVG}
           className="material-icons nsw-material-icons"
-          focusable="false"
-          aria-hidden="true"
-        >
-          search
-        </span>
+          size="36px"
+          ariaHidden={true}
+        />
         <span>
           <span className="sr-only">Show</span> Search
         </span>

--- a/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/src/customizations/volto/components/theme/Header/Header.jsx
@@ -1,6 +1,7 @@
 import loadable from '@loadable/component';
 import {
   Anontools,
+  Icon,
   LanguageSelector,
   Logo,
   SearchWidget,
@@ -13,6 +14,8 @@ import { useGoogleAnalytics } from 'volto-google-analytics';
 import Navigation from '../Navigation/Navigation';
 import { Masthead } from './Masthead';
 
+import MenuSVG from '@material-design-icons/svg/filled/menu.svg';
+
 const MenuOpenButton = () => (
   <div className="nsw-header__menu">
     <button
@@ -21,13 +24,12 @@ const MenuOpenButton = () => (
       aria-expanded="false"
       aria-controls="main-nav"
     >
-      <span
+      <Icon
+        name={MenuSVG}
         className="material-icons nsw-material-icons"
-        focusable="false"
-        aria-hidden="true"
-      >
-        menu
-      </span>
+        size="24px"
+        ariaHidden={true}
+      />
       <span>
         <span className="sr-only">Open</span> Menu
       </span>

--- a/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -1,12 +1,17 @@
 import loadable from '@loadable/component';
 import { getNavigation } from '@plone/volto/actions';
-import { UniversalLink as Link } from '@plone/volto/components';
+import { Icon, UniversalLink as Link } from '@plone/volto/components';
 import { getBaseUrl } from '@plone/volto/helpers';
 import config from '@plone/volto/registry';
 import React, { useEffect, useMemo, useRef } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
+
+import CloseSVG from '@material-design-icons/svg/filled/close.svg';
+import EastSVG from '@material-design-icons/svg/filled/east.svg';
+import KeyboardArrowLeftSVG from '@material-design-icons/svg/filled/keyboard_arrow_left.svg';
+import KeyboardArrowRightSVG from '@material-design-icons/svg/filled/keyboard_arrow_right.svg';
 
 const getItemUrl = (item) => {
   return item.url || item['@id'] || '';
@@ -53,13 +58,12 @@ const MainNavItem = ({ item }) => {
     <>
       <Link href={itemLink}>
         <span>{itemTitle}</span>
-        <span
+        <Icon
+          name={KeyboardArrowRightSVG}
           className="material-icons nsw-material-icons"
-          focusable="false"
-          aria-hidden="true"
-        >
-          keyboard_arrow_right
-        </span>
+          size="24px"
+          ariaHidden={true}
+        />
       </Link>
 
       {/* TODO: i18n messages for submenu labels */}
@@ -76,13 +80,12 @@ const MainNavItem = ({ item }) => {
             aria-expanded="true"
             aria-controls={navSubmenuId}
           >
-            <span
+            <Icon
+              name={KeyboardArrowLeftSVG}
               className="material-icons nsw-material-icons"
-              focusable="false"
-              aria-hidden="true"
-            >
-              keyboard_arrow_left
-            </span>
+              size="24px"
+              ariaHidden={true}
+            />
             <span>
               Back<span className="sr-only"> to previous menu</span>
             </span>
@@ -93,13 +96,12 @@ const MainNavItem = ({ item }) => {
             type="button"
             aria-expanded="true"
           >
-            <span
+            <Icon
+              name={CloseSVG}
               className="material-icons nsw-material-icons"
-              focusable="false"
-              aria-hidden="true"
-            >
-              close
-            </span>
+              size="24px"
+              ariaHidden={true}
+            />
             <span className="sr-only">Close Menu</span>
           </button>
         </div>
@@ -107,13 +109,12 @@ const MainNavItem = ({ item }) => {
         <div className="nsw-main-nav__title">
           <Link href={itemLink}>
             <span>{itemTitle}</span>
-            <span
+            <Icon
+              name={EastSVG}
               className="material-icons nsw-material-icons"
-              focusable="false"
-              aria-hidden="true"
-            >
-              east
-            </span>
+              size="24px"
+              ariaHidden={true}
+            />
           </Link>
         </div>
 
@@ -193,13 +194,12 @@ const Navigation = () => {
             type="button"
             aria-expanded="true"
           >
-            <span
+            <Icon
+              name={CloseSVG}
               className="material-icons nsw-material-icons"
-              focusable="false"
-              aria-hidden="true"
-            >
-              close
-            </span>
+              size="24px"
+              ariaHidden={true}
+            />
             <span className="sr-only">
               {intl.formatMessage(messages.closeMobileMenu)}
             </span>

--- a/src/customizations/volto/components/theme/Pagination/Pagination.jsx
+++ b/src/customizations/volto/components/theme/Pagination/Pagination.jsx
@@ -1,9 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { UniversalLink } from '@plone/volto/components';
+import { Icon, UniversalLink } from '@plone/volto/components';
 import { FormattedMessage } from 'react-intl';
 import { Menu } from 'semantic-ui-react';
+
+import KeyboardArrowLeftSVG from '@material-design-icons/svg/filled/keyboard_arrow_left.svg';
+import KeyboardArrowRightSVG from '@material-design-icons/svg/filled/keyboard_arrow_right.svg';
 
 const NumberedPage = ({ pageNumber, onClick, isCurrent = false }) => {
   return (
@@ -49,13 +52,12 @@ const Pagination = ({
                 onChangePage(e, { activePage: current - 1 });
               }}
             >
-              <span
+              <Icon
+                name={KeyboardArrowLeftSVG}
                 className="material-icons nsw-material-icons"
-                focusable="false"
-                aria-hidden="true"
-              >
-                keyboard_arrow_left
-              </span>
+                size="24px"
+                ariaHidden={true}
+              />
               <span className="sr-only">Back</span>
             </UniversalLink>
           </li>
@@ -104,13 +106,12 @@ const Pagination = ({
                 onChangePage(e, { activePage: current + 1 });
               }}
             >
-              <span
+              <Icon
+                name={KeyboardArrowRightSVG}
                 className="material-icons nsw-material-icons"
-                focusable="false"
-                aria-hidden="true"
-              >
-                keyboard_arrow_right
-              </span>
+                size="24px"
+                ariaHidden={true}
+              />
               <span className="sr-only">Next</span>
             </UniversalLink>
           </li>

--- a/src/customizations/volto/components/theme/SearchWidget/SearchWidget.jsx
+++ b/src/customizations/volto/components/theme/SearchWidget/SearchWidget.jsx
@@ -1,6 +1,10 @@
+import { Icon } from '@plone/volto/components';
 import React, { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useHistory, useLocation } from 'react-router-dom';
+
+import CloseSVG from '@material-design-icons/svg/filled/close.svg';
+import SearchSVG from '@material-design-icons/svg/filled/search.svg';
 
 const messages = defineMessages({
   search: {
@@ -56,14 +60,12 @@ const SearchWidget = () => {
           //   placeholder={intl.formatMessage(messages.searchSite)}
         />
         <button className="nsw-icon-button nsw-icon-button--flex" type="submit">
-          <span
+          <Icon
+            name={SearchSVG}
             className="material-icons nsw-material-icons"
-            focusable="false"
-            aria-hidden="true"
-          >
-            {/* This text is used to set the material icon, doesn't need i18n */}
-            search
-          </span>
+            size="24px"
+            ariaHidden={true}
+          />
           <span className="sr-only">{intl.formatMessage(messages.search)}</span>
         </button>
       </form>
@@ -72,14 +74,12 @@ const SearchWidget = () => {
         aria-expanded="true"
         aria-controls="header-search"
       >
-        <span
+        <Icon
+          name={CloseSVG}
           className="material-icons nsw-material-icons"
-          focusable="false"
-          aria-hidden="true"
-        >
-          {/* This text is used to set the material icon, doesn't need i18n */}
-          close
-        </span>
+          size="24px"
+          ariaHidden={true}
+        />
         <span className="sr-only">
           {intl.formatMessage(messages.closeSearch)}
         </span>

--- a/src/customizations/volto/components/theme/SearchWidget/SearchWidget.jsx
+++ b/src/customizations/volto/components/theme/SearchWidget/SearchWidget.jsx
@@ -63,7 +63,7 @@ const SearchWidget = () => {
           <Icon
             name={SearchSVG}
             className="material-icons nsw-material-icons"
-            size="24px"
+            size="36px"
             ariaHidden={true}
           />
           <span className="sr-only">{intl.formatMessage(messages.search)}</span>

--- a/src/theme.js
+++ b/src/theme.js
@@ -4,3 +4,5 @@ import '@fontsource/public-sans/700-italic.css';
 import '@fontsource/public-sans/700.css';
 import 'material-icons/iconfont/material-icons.css';
 import 'nsw-design-system/dist/css/main.css';
+
+import './custom.less';


### PR DESCRIPTION
This PR replaces most uses of material font-icons with SVGs. This should remove the FOUC from having to load the icon fonts.

The only remaining usage of font-icons are those inserted by the JavaScript of the accordion component (there's no easy way to replace this without a PR to to the nsw-design-system and those used in the `FilterList` component (shown when a filter has been inserted in the search block and can be removed). This is due to the icon height causing the button height to increase.