### PR TITLE
Initial hero width implementation

### DIFF
--- a/src/components/Blocks/Hero/variations/HeroWithBlocks.jsx
+++ b/src/components/Blocks/Hero/variations/HeroWithBlocks.jsx
@@ -20,6 +20,7 @@ export const HeroWithBlocks = ({ data, ...props }) => {
         imageUrl={imageUrl}
         linkTitle={data.linkTitle}
         linkUrl={linkUrl}
+        width={data.heroWidth}
         contentChildren={
           <RenderBlocks {...props} metadata={metadata} content={data.block} />
         }

--- a/src/components/Blocks/Hero/variations/HeroWithDropdownQuickNavigation.jsx
+++ b/src/components/Blocks/Hero/variations/HeroWithDropdownQuickNavigation.jsx
@@ -19,6 +19,7 @@ export const HeroWithDropdownQuickNavigation = ({ data, ...props }) => {
         imageUrl={imageUrl}
         linkTitle={data.linkTitle}
         linkUrl={linkUrl}
+        width={data.heroWidth}
         contentChildren={<DropdownQuickNavigationView {...props} data={data} />}
       />
     </>

--- a/src/components/Blocks/Hero/variations/HeroWithLinks.jsx
+++ b/src/components/Blocks/Hero/variations/HeroWithLinks.jsx
@@ -28,6 +28,7 @@ export const HeroWithLinks = ({ data, ...props }) => {
         linkUrl={linkUrl}
         linksTitle={data.linksTitle || ''}
         linksList={linksList}
+        width={data.heroWidth}
       />
     </>
   );

--- a/src/components/Components/Hero.jsx
+++ b/src/components/Components/Hero.jsx
@@ -1,4 +1,11 @@
 import React from 'react';
+import cx from 'classnames';
+import './Hero.less';
+
+const widthClassnameMapping = {
+  wide: 'nsw-hero-banner--wide',
+  extraWide: 'nsw-hero-banner--extra-wide',
+};
 
 export const Hero = ({
   title,
@@ -8,12 +15,17 @@ export const Hero = ({
   linkUrl = null,
   linksTitle = '',
   linksList = [],
+  width = 'default',
   contentChildren,
   boxChildren,
 }) => {
   return (
     // TODO: There's a hidden `nsw-hero-banner--wide` class that makes the text longer, but it causes overflow
-    <div className="nsw-hero-banner nsw-hero-banner--dark">
+    <div
+      className={cx('nsw-hero-banner nsw-hero-banner--dark', {
+        [widthClassnameMapping[width]]: width !== 'default',
+      })}
+    >
       <div className="nsw-hero-banner__container">
         <div className="nsw-hero-banner__wrapper">
           <div className="nsw-hero-banner__content">

--- a/src/components/Components/Hero.less
+++ b/src/components/Components/Hero.less
@@ -1,0 +1,14 @@
+.nsw-hero-banner {
+  &--extra-wide {
+    @media (min-width: 48rem) {
+      .nsw-hero-banner__content {
+        width: 67%;
+        max-width: 67%;
+      }
+      .nsw-hero-banner__box,
+      .nsw-hero-banner__links {
+        max-width: 23%;
+      }
+    }
+  }
+}

--- a/src/config/blocks.js
+++ b/src/config/blocks.js
@@ -55,6 +55,10 @@ const messages = defineMessages({
     id: 'Number of columns',
     defaultMessage: 'Number of columns',
   },
+  heroWidth: {
+    id: 'Width',
+    defaultMessage: 'Width',
+  },
   // Media schema
   size: {
     id: 'Size',
@@ -377,6 +381,32 @@ const schemaEnhancers = {
       schema.fieldsets[0].fields.splice(indexToRemove, 1);
       delete schema.properties[field];
     });
+    return schema;
+  },
+  hero: ({ schema, intl }) => {
+    schema.properties.heroWidth = {
+      title: intl.formatMessage(messages.heroWidth),
+      type: 'string',
+      factory: 'Choice',
+      // TODO: i18n hero width choices
+      choices: [
+        ['default', 'Default'],
+        ['wide', 'Wide'],
+        ['extraWide', 'Extra wide'],
+      ],
+      default: 'default',
+    };
+    const defaultFieldsetIndex = schema.fieldsets.findIndex(
+      (fieldset) => fieldset.id === 'default',
+    );
+    schema.fieldsets[defaultFieldsetIndex].fields = [
+      ...schema.fieldsets[defaultFieldsetIndex].fields,
+      'heroWidth',
+    ];
+    schema.fieldsets[defaultFieldsetIndex].required = [
+      ...(schema.fieldsets[defaultFieldsetIndex]?.fields ?? []),
+      'heroWidth',
+    ];
     return schema;
   },
   search: ({ schema, intl }) => {

--- a/src/customizations/volto/components/manage/Blocks/HeroImageLeft/Edit.jsx
+++ b/src/customizations/volto/components/manage/Blocks/HeroImageLeft/Edit.jsx
@@ -432,6 +432,7 @@ class EditComponent extends Component {
           imageUrl={null}
           linkTitle={this.props.data.linkTitle}
           linkHref={null}
+          width={this.props.data.width}
           contentChildren={
             <>
               <Editor

--- a/src/customizations/volto/components/manage/Blocks/HeroImageLeft/View.jsx
+++ b/src/customizations/volto/components/manage/Blocks/HeroImageLeft/View.jsx
@@ -24,6 +24,7 @@ const View = ({ data, ...props }) => {
         imageUrl={imageUrl}
         linkTitle={data.linkTitle}
         linkUrl={linkUrl}
+        width={data.heroWidth}
       />
     );
   }


### PR DESCRIPTION
This PR adds an option to add the `nsw-hero-banner__wide` class to hero banners, allowing the title to be a little wider. A custom `extra-wide` option was also added, but this may not conform to Masterbrand guidelines. Feedback is welcome!