### PR TITLE
Initial listing controls

### DIFF
--- a/src/components/Blocks/Card/Edit.jsx
+++ b/src/components/Blocks/Card/Edit.jsx
@@ -1,13 +1,9 @@
 import { BlockDataForm, SidebarPortal } from '@plone/volto/components';
 import React from 'react';
-import { useIntl } from 'react-intl';
 import CardSchema from './schema';
 import Card from './View';
 
-const CardEditDisplay = ({ data, id, isEditMode, onSelectBlock }) => {
-  const intl = useIntl();
-  const { title, description } = data;
-
+const CardEditDisplay = ({ data, isEditMode }) => {
   return <Card data={data} isEditMode={isEditMode} />;
 };
 

--- a/src/components/Blocks/Card/View.jsx
+++ b/src/components/Blocks/Card/View.jsx
@@ -1,7 +1,5 @@
 import { flattenToAppURL, isInternalURL } from '@plone/volto/helpers';
-import cx from 'classnames';
-import React from 'react';
-import { Link } from 'react-router-dom';
+import { Card } from 'nsw-design-system-plone6/components/Components/Card';
 
 // TODO: Support adding alt text to images
 const CardView = ({ data, isEditMode }) => {
@@ -9,43 +7,8 @@ const CardView = ({ data, isEditMode }) => {
   if (isInternalURL(href)) {
     href = flattenToAppURL(href);
   }
-  const linkTitle = data.title || href;
 
-  return (
-    <div
-      className={cx('nsw-card', {
-        'nsw-card--headline': data.titleIsHeadline,
-        'nsw-card--highlight': data.shouldHighlight,
-        'nsw-card--light': data.colour === 'light',
-        'nsw-card--dark': data.colour === 'dark',
-        'nsw-card--horizontal': data.imagePosition === 'side',
-      })}
-    >
-      {data.image ? (
-        <div className="nsw-card__image">
-          <img
-            src={`data:${data.image['content-type']};base64,${data.image.data}`}
-            alt=""
-          />
-        </div>
-      ) : null}
-      <div className="nsw-card__content">
-        <div className="nsw-card__title">
-          {!isEditMode ? <Link to={href}>{linkTitle}</Link> : linkTitle}
-        </div>
-        {data.description ? (
-          <div className="nsw-card__copy">{data.description}</div>
-        ) : null}
-        <span
-          className="material-icons nsw-material-icons"
-          focusable="false"
-          aria-hidden="true"
-        >
-          east
-        </span>
-      </div>
-    </div>
-  );
+  return <Card {...data} href={href} />;
 };
 
 export default CardView;

--- a/src/components/Blocks/Card/View.jsx
+++ b/src/components/Blocks/Card/View.jsx
@@ -8,7 +8,7 @@ const CardView = ({ data, isEditMode }) => {
     href = flattenToAppURL(href);
   }
 
-  return <Card {...data} href={href} />;
+  return <Card {...data} href={href} isEditMode={isEditMode} />;
 };
 
 export default CardView;

--- a/src/components/Blocks/Listing/CardListing.jsx
+++ b/src/components/Blocks/Listing/CardListing.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { CardView } from '../Card';
+import { flattenToAppURL, isInternalURL } from '@plone/volto/helpers';
+import { Card } from 'nsw-design-system-plone6/components/Components/Card';
 
 const numberOfColumnsClassMapping = {
   1: 'nsw-col',
@@ -8,19 +8,39 @@ const numberOfColumnsClassMapping = {
   4: 'nsw-col nsw-col-md-6 nsw-col-lg-3',
 };
 
-const CardListing = ({ items, isEditMode, ...data }) => {
+export function CardListing({ items, isEditMode, ...data }) {
   return (
     <div className="nsw-grid">
-      {items.map((item) => (
-        <div
-          key={item['@id']}
-          className={numberOfColumnsClassMapping[data.numberOfColumns]}
-        >
-          <CardView data={{ ...data, ...item }} isEditMode={isEditMode} />
-        </div>
-      ))}
+      {items.map((item) => {
+        let href = item.link?.[0]?.['@id'] || item['@id'] || '';
+        if (isInternalURL(href)) {
+          href = flattenToAppURL(href);
+        }
+
+        const image =
+          data.imagePosition !== 'hidden' && item.image_field
+            ? `${flattenToAppURL(item['@id'])}/@@images/${
+                item.image_field
+              }/teaser`
+            : null;
+
+        return (
+          <div
+            key={item['@id']}
+            className={numberOfColumnsClassMapping[data.numberOfColumns]}
+          >
+            <Card
+              {...data}
+              {...item}
+              image={image}
+              href={href}
+              urlDisplay={data.showUrl ? href : null}
+              date={data.showDate ? item[data.dateField] : null}
+              isEditMode={isEditMode}
+            />
+          </div>
+        );
+      })}
     </div>
   );
-};
-
-export default CardListing;
+}

--- a/src/components/Components/Card.jsx
+++ b/src/components/Components/Card.jsx
@@ -1,0 +1,78 @@
+import { FormattedDate, Icon } from '@plone/volto/components';
+import cx from 'classnames';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import EastSVG from '@material-design-icons/svg/filled/east.svg';
+
+// TODO: Support adding alt text to images
+export function Card({
+  title,
+  titleIsHeadline,
+  description,
+  href,
+  image,
+  imagePosition,
+  date,
+  urlDisplay,
+  colour,
+  shouldHighlight,
+  isEditMode,
+}) {
+  const linkTitle = title || href;
+
+  return (
+    <div
+      className={cx('nsw-card', {
+        'nsw-card--headline': titleIsHeadline,
+        'nsw-card--highlight': shouldHighlight,
+        'nsw-card--light': colour === 'light',
+        'nsw-card--dark': colour === 'dark',
+        'nsw-card--horizontal': imagePosition === 'side',
+      })}
+    >
+      {image ? (
+        <div className="nsw-card__image">
+          <img
+            src={
+              typeof image === 'string'
+                ? image
+                : `data:${image['content-type']};base64,${image.data}`
+            }
+            alt=""
+          />
+        </div>
+      ) : null}
+      <div className="nsw-card__content">
+        {date || urlDisplay ? (
+          <div className="nsw-card__date">
+            {date ? <FormattedDate date={date} locale="en-au" /> : null}
+            {urlDisplay ? (
+              <p style={{ marginBlockEnd: '0' }}>{urlDisplay}</p>
+            ) : null}
+          </div>
+        ) : null}
+        <div className="nsw-card__title">
+          {!isEditMode ? <Link to={href}>{linkTitle}</Link> : linkTitle}
+        </div>
+        {description ? (
+          <div className="nsw-card__copy">{description}</div>
+        ) : null}
+
+        <Icon
+          name={EastSVG}
+          className="material-icons nsw-material-icons"
+          size="1.875rem"
+          ariaHidden={true}
+        />
+        {/* <span
+          className="material-icons nsw-material-icons"
+          focusable="false"
+          aria-hidden="true"
+        >
+          east
+        </span> */}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Components/Card.jsx
+++ b/src/components/Components/Card.jsx
@@ -20,6 +20,7 @@ export function Card({
   isEditMode,
 }) {
   const linkTitle = title || href;
+  const cleanDate = date === 'None' ? null : date;
 
   return (
     <div
@@ -44,9 +45,11 @@ export function Card({
         </div>
       ) : null}
       <div className="nsw-card__content">
-        {date || urlDisplay ? (
+        {cleanDate || urlDisplay ? (
           <div className="nsw-card__date">
-            {date ? <FormattedDate date={date} locale="en-au" /> : null}
+            {cleanDate ? (
+              <FormattedDate date={cleanDate} locale="en-au" />
+            ) : null}
             {urlDisplay ? (
               <p style={{ marginBlockEnd: '0' }}>{urlDisplay}</p>
             ) : null}

--- a/src/config/blocks.js
+++ b/src/config/blocks.js
@@ -10,7 +10,7 @@ import {
 import * as Components from '../components';
 import { CardSchema } from '../components/Blocks/Card';
 import { DropdownQuickNavigationSchema } from '../components/Blocks/DropdownQuickNavigation/schema';
-import CardListing from '../components/Blocks/Listing/CardListing';
+import { CardListing } from '../components/Blocks/Listing/CardListing';
 import { SectionSchema } from '../components/Blocks/Section';
 
 const messages = defineMessages({
@@ -399,17 +399,20 @@ const schemaEnhancers = {
       title: 'Show tags',
       type: 'boolean',
     };
-    schema.properties.imagePosition = {
-      title: 'Image position',
-      type: 'string',
-      factory: 'Choice',
-      choices: [
-        ['hidden', 'Hidden'],
-        ['left', 'Left'],
-        ['right', 'Right'],
-      ],
-      default: 'hidden',
-    };
+    // Below check needed so we don't overwrite the card settings
+    schema.properties.imagePosition = schema.properties.imagePosition
+      ? schema.properties.imagePosition
+      : {
+          title: 'Image position',
+          type: 'string',
+          factory: 'Choice',
+          choices: [
+            ['hidden', 'Hidden'],
+            ['left', 'Left'],
+            ['right', 'Right'],
+          ],
+          default: 'hidden',
+        };
     schema.properties.dateField = {
       title: 'Date field',
       type: 'string',
@@ -430,9 +433,10 @@ const schemaEnhancers = {
         'showUrl',
         'showTags',
         'showDate',
-        ...[formData.showDate ? ['dateField'] : []],
-        'imagePosition',
-        'clickableArea',
+        ...(formData.showDate ? ['dateField'] : []),
+        ...(formData.variation !== 'cardListing'
+          ? ['imagePosition', 'clickableArea']
+          : []),
       ],
       required: [],
     };

--- a/src/config/blocks.js
+++ b/src/config/blocks.js
@@ -364,19 +364,75 @@ function asMediaSchemaExtender(schema, intl, formData) {
 }
 
 const schemaEnhancers = {
-  video: ({ schema, intl, formData }) => {
-    return asMediaSchemaExtender(schema, intl, formData);
-  },
   image: ({ schema, intl, formData }) => {
     return asMediaSchemaExtender(schema, intl, formData);
   },
-  toc: ({ schema }) => {
-    const fieldsToRemove = ['title', 'hide_title', 'ordered'];
-    fieldsToRemove.map((field) => {
-      const indexToRemove = schema.fieldsets[0].fields.indexOf(field);
-      schema.fieldsets[0].fields.splice(indexToRemove, 1);
-      delete schema.properties[field];
-    });
+  listing: ({ schema, intl, formData }) => {
+    schema.properties.clickableArea = {
+      title: 'Clickable area',
+      type: 'string',
+      factory: 'Choice',
+      choices: [
+        ['title', 'Title only'],
+        ['block', 'All of item'],
+      ],
+      default: 'title',
+    };
+    schema.properties.showDescription = {
+      title: 'Show description',
+      type: 'boolean',
+      default: true,
+    };
+    schema.properties.showUrl = {
+      title: 'Show URL',
+      type: 'boolean',
+    };
+    schema.properties.showDate = {
+      title: 'Show date',
+      type: 'boolean',
+    };
+    schema.properties.showTags = {
+      title: 'Show tags',
+      type: 'boolean',
+    };
+    schema.properties.imagePosition = {
+      title: 'Image position',
+      type: 'string',
+      factory: 'Choice',
+      choices: [
+        ['hidden', 'Hidden'],
+        ['left', 'Left'],
+        ['right', 'Right'],
+      ],
+      default: 'hidden',
+    };
+    schema.properties.dateField = {
+      title: 'Date field',
+      type: 'string',
+      factory: 'Choice',
+      choices: [
+        ['CreationDate', 'Creation date'],
+        ['EffectiveDate', 'Publication date'],
+        ['ModificationDate', 'Last modified'],
+        ['ExpirationDate', 'Expiration date'],
+      ],
+      default: 'EffectiveDate',
+    };
+    const itemDisplayFieldset = {
+      id: 'listingDisplayFieldset',
+      title: 'Item Settings',
+      fields: [
+        'showDescription',
+        'showUrl',
+        'showTags',
+        'showDate',
+        ...[formData.showDate ? ['dateField'] : []],
+        'imagePosition',
+        'clickableArea',
+      ],
+      required: [],
+    };
+    schema.fieldsets.push(itemDisplayFieldset);
     return schema;
   },
   search: ({ schema, intl }) => {
@@ -394,6 +450,18 @@ const schemaEnhancers = {
       'fullWidthSearchBar',
     ];
     return schema;
+  },
+  toc: ({ schema }) => {
+    const fieldsToRemove = ['title', 'hide_title', 'ordered'];
+    fieldsToRemove.map((field) => {
+      const indexToRemove = schema.fieldsets[0].fields.indexOf(field);
+      schema.fieldsets[0].fields.splice(indexToRemove, 1);
+      delete schema.properties[field];
+    });
+    return schema;
+  },
+  video: ({ schema, intl, formData }) => {
+    return asMediaSchemaExtender(schema, intl, formData);
   },
 };
 

--- a/src/customizations/volto-form-block/components/Widget/FileWidget.jsx
+++ b/src/customizations/volto-form-block/components/Widget/FileWidget.jsx
@@ -238,7 +238,7 @@ const FileWidget = (props) => {
             )}
 
             <div className="">{value && value.filename}</div>
-            <button className="nsw-button nsw-button--dark">
+            <button type="button" className="nsw-button nsw-button--dark">
               {value
                 ? intl.formatMessage(messages.replaceFile)
                 : intl.formatMessage(messages.addNewFile)}

--- a/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
@@ -1,7 +1,7 @@
 import { ConditionalLink } from '@plone/volto/components';
+import { flattenToAppURL } from '@plone/volto/helpers';
 import config from '@plone/volto/registry';
 import cx from 'classnames';
-import React from 'react';
 import { useCookies } from 'react-cookie';
 
 // TODO: Customisable datetime format
@@ -15,6 +15,12 @@ const ListItemsTemplate = ({ items, isEditMode, ...data }) => {
   return (
     <div className="nsw-list-items">
       {items.map((item) => {
+        const image =
+          data.imagePosition !== 'hidden' && item.image_field
+            ? `${flattenToAppURL(item['@id'])}/@@images/${
+                item.image_field
+              }/teaser`
+            : null;
         return (
           <div
             key={item['@id']}
@@ -57,9 +63,9 @@ const ListItemsTemplate = ({ items, isEditMode, ...data }) => {
                 </div>
               ) : null}
             </div>
-            {data.imagePosition !== 'hidden' ? (
+            {data.imagePosition !== 'hidden' && image ? (
               <div class="nsw-list-item__image">
-                <img src="https://picsum.photos/id/3/400/200" alt="" />
+                <img src={image} alt="" />
               </div>
             ) : null}
           </div>

--- a/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
@@ -1,36 +1,67 @@
 import { ConditionalLink } from '@plone/volto/components';
+import cx from 'classnames';
 import React from 'react';
 
-const ListItemsTemplate = ({ items, isEditMode, ...rest }) => {
+// TODO: Customisable datetime format
+const dateTimeFormat = new Intl.DateTimeFormat(navigator.language, {
+  style: 'long',
+});
+
+const ListItemsTemplate = ({ items, isEditMode, ...data }) => {
   return (
     <div className="nsw-list-items">
-      {items.map((item) => (
-        <div key={item['@id']} className="nsw-list-item">
-          <div className="nsw-list-item__content">
-            {/* TODO: Find a way to allow adjustable labels */}
-            {/* <div className="nsw-list-item__label">Stories</div> */}
-            <div className="nsw-list-item__title">
-              <ConditionalLink item={item} condition={!isEditMode}>
-                {item.title ? item.title : item.id}
-              </ConditionalLink>
-            </div>
-            <div className="nsw-list-item__copy">{item.description}</div>
-            {item.Subject ? (
-              <div className="nsw-list-item__tags">
-                <div className="nsw-list nsw-list--8">
-                  {item.Subject.map((tagText) => {
-                    return (
-                      <span key={tagText} className="nsw-tag">
-                        {tagText}
-                      </span>
-                    );
-                  })}
+      {items.map((item) => {
+        console.log(item);
+        return (
+          <div
+            key={item['@id']}
+            className={cx('nsw-list-item', {
+              'nsw-list-item--block': data.clickableArea === 'block',
+              'nsw-list-item--reversed': data.imagePosition === 'left', // This is how the NSW Design System docs recommend it is done, but this should be done in HTML
+            })}
+          >
+            <div className="nsw-list-item__content">
+              {/* TODO: Find a way to allow adjustable labels */}
+              {/* <div className="nsw-list-item__label">Stories</div> */}
+              <div className="nsw-list-item__title">
+                <ConditionalLink item={item} condition={!isEditMode}>
+                  {item.title ? item.title : item.id}
+                </ConditionalLink>
+              </div>
+              {data.showUrl || data.showDate ? (
+                <div class="nsw-list-item__info">
+                  {data.showUrl ? item.getURL : null}
+                  {data.showDate
+                    ? dateTimeFormat.format(new Date(item[data.dateField]))
+                    : null}
                 </div>
+              ) : null}
+
+              {!data.showDescription ? null : (
+                <div className="nsw-list-item__copy">{item.description}</div>
+              )}
+              {data.showTags && item.Subject?.length > 0 ? (
+                <div className="nsw-list-item__tags">
+                  <div className="nsw-list nsw-list--8">
+                    {item.Subject.map((tagText) => {
+                      return (
+                        <span key={tagText} className="nsw-tag">
+                          {tagText}
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+            {data.imagePosition !== 'hidden' ? (
+              <div class="nsw-list-item__image">
+                <img src="https://picsum.photos/id/3/400/200" alt="" />
               </div>
             ) : null}
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
@@ -1,4 +1,4 @@
-import { ConditionalLink } from '@plone/volto/components';
+import { ConditionalLink, FormattedDate } from '@plone/volto/components';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import config from '@plone/volto/registry';
 import cx from 'classnames';
@@ -21,6 +21,8 @@ const ListItemsTemplate = ({ items, isEditMode, ...data }) => {
                 item.image_field
               }/teaser`
             : null;
+        const date =
+          item[data.dateField] === 'None' ? null : item[data.dateField];
         return (
           <div
             key={item['@id']}
@@ -40,9 +42,9 @@ const ListItemsTemplate = ({ items, isEditMode, ...data }) => {
               {data.showUrl || data.showDate ? (
                 <div class="nsw-list-item__info">
                   {data.showUrl ? item.getURL : null}
-                  {data.showDate
-                    ? dateTimeFormat.format(new Date(item[data.dateField]))
-                    : null}
+                  {data.showDate && date ? (
+                    <FormattedDate date={date} locale="en-au" />
+                  ) : null}
                 </div>
               ) : null}
 

--- a/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
@@ -15,7 +15,6 @@ const ListItemsTemplate = ({ items, isEditMode, ...data }) => {
   return (
     <div className="nsw-list-items">
       {items.map((item) => {
-        console.log(item);
         return (
           <div
             key={item['@id']}

--- a/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
@@ -1,13 +1,17 @@
 import { ConditionalLink } from '@plone/volto/components';
+import config from '@plone/volto/registry';
 import cx from 'classnames';
 import React from 'react';
+import { useCookies } from 'react-cookie';
 
 // TODO: Customisable datetime format
-const dateTimeFormat = new Intl.DateTimeFormat(navigator.language, {
-  style: 'long',
-});
-
 const ListItemsTemplate = ({ items, isEditMode, ...data }) => {
+  const [cookies] = useCookies();
+  const currentLanguage =
+    cookies['I18N_LANGUAGE'] || config.settings.defaultLanguage;
+  const dateTimeFormat = new Intl.DateTimeFormat(currentLanguage, {
+    style: 'long',
+  });
   return (
     <div className="nsw-list-items">
       {items.map((item) => {


### PR DESCRIPTION
This PR introduces controls to allow editors to change what content is displayed in their listings. Editors can toggle whether only the title or the whole link is clickable and if the dates, the URL, the tags and the preview image are visible. The date field that is displayed can be chosen (e.g. Created date or Published date) and the positioning of the image adjusted (left or right side). This works with both the default listing style and the list of cards.

<img width="385" alt="Screenshot 2022-12-15 at 3 23 38 pm" src="https://user-images.githubusercontent.com/30210785/207899378-2d432814-9dac-46df-9e53-941498e888c9.png">
<img width="366" alt="Screenshot 2022-12-15 at 3 22 25 pm" src="https://user-images.githubusercontent.com/30210785/207899384-7dbe0b42-98e6-4960-8acf-57071bbff837.png">
