### PR TITLE
Set `blockHasOwnFocusManagement` to true for form block

### DIFF
--- a/src/config/blocks.js
+++ b/src/config/blocks.js
@@ -644,6 +644,8 @@ export const updateBlocksConfig = (config) => {
     config.blocks.blocksConfig[block.id] = { sidebarTab: 1, ...block };
   });
 
+  config.blocks.blocksConfig['form'].blockHasOwnFocusManagement = true;
+
   Object.entries(blockVariations).forEach(([blockId, variations]) => {
     config.blocks.blocksConfig[blockId].variations = [
       ...(config.blocks.blocksConfig[blockId].variations ?? []),


### PR DESCRIPTION
Fixes being unable to add a paragraph in the form block 'static text' field