### PR TITLE
Initial implementation of manual SortOn

### DIFF
--- a/src/customizations/volto/components/manage/Blocks/Search/components/SortOn.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/components/SortOn.jsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
 const messages = defineMessages({
   noSelection: {
-    id: 'No selection',
-    defaultMessage: 'No selection',
+    id: 'Relevance',
+    defaultMessage: 'Relevance',
   },
   sortBy: {
     id: 'Sort by',
@@ -12,30 +11,42 @@ const messages = defineMessages({
   },
 });
 
+const sortOptions = {
+  Relevance: {
+    sort_on: '',
+    sort_order: '',
+  },
+  'Most recent': {
+    sort_on: 'created',
+    sort_order: 'descending',
+  },
+  'A-Z': {
+    sort_on: 'sortable_title',
+    sort_order: 'ascending',
+  },
+};
+
 const SortOn = (props) => {
   const {
     data = {},
     sortOn = null,
     isEditMode,
     querystring = {},
-    setSortOn,
+    updateSort,
   } = props;
-  const { sortable_indexes } = querystring;
-
   const intl = useIntl();
 
   const activeSortOn = sortOn || data?.query?.sort_on || '';
-
-  const { sortOnOptions = [] } = data;
-  const value = activeSortOn || intl.formatMessage(messages.noSelection);
-  const label =
-    activeSortOn && sortable_indexes
-      ? sortable_indexes[activeSortOn]?.title
-      : activeSortOn || intl.formatMessage(messages.noSelection);
+  const value =
+    Object.keys(sortOptions)[
+      Object.values(sortOptions).findIndex(
+        (option) => option.sort_on === activeSortOn,
+      )
+    ] || intl.formatMessage(messages.noSelection);
 
   return (
     <div className="nsw-results-bar__sorting">
-      <label className="nsw-form__label" for="results-sort">
+      <label className="nsw-form__label" htmlFor="results-sort">
         {data.sortOnLabel || intl.formatMessage(messages.sortBy)}
       </label>
       {/* eslint-disable-next-line jsx-a11y/no-onchange */}
@@ -46,14 +57,19 @@ const SortOn = (props) => {
         name="results-sort"
         value={value}
         onChange={({ target }) => {
-          !isEditMode && setSortOn(target.value);
+          if (isEditMode) {
+            return;
+          }
+          updateSort({
+            sortOn: sortOptions[target.value].sort_on,
+            sortOrder: sortOptions[target.value].sort_order,
+          });
         }}
       >
-        {sortOnOptions.map((sortKey) => {
-          const label = sortable_indexes[sortKey]?.title || sortKey;
+        {Object.keys(sortOptions).map((sortOption) => {
           return (
-            <option key={sortKey} value={sortKey}>
-              {label}
+            <option key={sortOption} value={sortOption}>
+              {sortOption}
             </option>
           );
         })}

--- a/src/customizations/volto/components/manage/Blocks/Search/hocs/withSearch.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/hocs/withSearch.jsx
@@ -1,0 +1,353 @@
+import qs from 'query-string';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useHistory, useLocation } from 'react-router-dom';
+
+import { resolveExtension } from '@plone/volto/helpers/Extensions/withBlockExtensions';
+import config from '@plone/volto/registry';
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
+const SEARCH_ENDPOINT_FIELDS = [
+  'SearchableText',
+  'b_size',
+  'limit',
+  'sort_on',
+  'sort_order',
+];
+
+const PAQO = 'plone.app.querystring.operation';
+
+/**
+ * Based on URL state, gets an initial internal state for the search
+ *
+ * @function getInitialState
+ *
+ */
+function getInitialState(data, facets, urlSearchText, id) {
+  const {
+    types: facetWidgetTypes,
+  } = config.blocks.blocksConfig.search.extensions.facetWidgets;
+  const facetSettings = data?.facets || [];
+
+  return {
+    query: [
+      ...(data.query?.query || []),
+      ...(facetSettings || [])
+        .map((facet) => {
+          if (!facet?.field) return null;
+
+          const { valueToQuery } = resolveExtension(
+            'type',
+            facetWidgetTypes,
+            facet,
+          );
+
+          const name = facet.field.value;
+          const value = facets[name];
+
+          return valueToQuery({ value, facet });
+        })
+        .filter((f) => !!f),
+      ...(urlSearchText
+        ? [
+            {
+              i: 'SearchableText',
+              o: 'plone.app.querystring.operation.string.contains',
+              v: urlSearchText,
+            },
+          ]
+        : []),
+    ],
+    sort_on: data.query?.sort_on,
+    sort_order: data.query?.sort_order,
+    b_size: data.query?.b_size,
+    limit: data.query?.limit,
+    block: id,
+  };
+}
+
+/**
+ * "Normalizes" the search state to something that's serializable
+ * (for querying) and used to compute data for the ListingBody
+ *
+ * @function normalizeState
+ *
+ */
+function normalizeState({
+  query, // base query
+  facets, // facet values
+  id, // block id
+  searchText, // SearchableText
+  sortOn,
+  sortOrder,
+  facetSettings, // data.facets extracted from block data
+}) {
+  const {
+    types: facetWidgetTypes,
+  } = config.blocks.blocksConfig.search.extensions.facetWidgets;
+
+  const params = {
+    query: [
+      ...(query.query || []),
+      ...(facetSettings || []).map((facet) => {
+        if (!facet?.field) return null;
+
+        const { valueToQuery } = resolveExtension(
+          'type',
+          facetWidgetTypes,
+          facet,
+        );
+
+        const name = facet.field.value;
+        const value = facets[name];
+
+        return valueToQuery({ value, facet });
+      }),
+    ].filter((o) => !!o),
+    sort_on: sortOn || query.sort_on,
+    sort_order: sortOrder || query.sort_order,
+    b_size: query.b_size,
+    limit: query.limit,
+    block: id,
+  };
+
+  // TODO: need to check if SearchableText facet is not already in the query
+  // Ideally the searchtext functionality should be restructured as being just
+  // another facet
+  params.query = params.query.reduce(
+    // Remove SearchableText from query
+    (acc, kvp) => (kvp.i === 'SearchableText' ? acc : [...acc, kvp]),
+    [],
+  );
+  if (searchText) {
+    params.query.push({
+      i: 'SearchableText',
+      o: 'plone.app.querystring.operation.string.contains',
+      v: searchText,
+    });
+  }
+
+  return params;
+}
+
+const getSearchFields = (searchData) => {
+  return Object.assign(
+    {},
+    ...SEARCH_ENDPOINT_FIELDS.map((k) => {
+      return searchData[k] ? { [k]: searchData[k] } : {};
+    }),
+    searchData.query ? { query: serializeQuery(searchData['query']) } : {},
+  );
+};
+
+/**
+ * A HOC that will mirror the search block state to a hash location
+ */
+const useHashState = () => {
+  const location = useLocation();
+  const history = useHistory();
+
+  const oldState = React.useMemo(() => {
+    return {
+      ...qs.parse(location.search),
+      ...qs.parse(location.hash),
+    };
+  }, [location.hash, location.search]);
+
+  // This creates a shallow copy. Why is this needed?
+  const current = Object.assign(
+    {},
+    ...Array.from(Object.keys(oldState)).map((k) => ({ [k]: oldState[k] })),
+  );
+
+  const setSearchData = React.useCallback(
+    (searchData) => {
+      const newParams = qs.parse(location.hash);
+
+      let changed = false;
+
+      Object.keys(searchData)
+        .sort()
+        .forEach((k) => {
+          if (searchData[k]) {
+            newParams[k] = searchData[k];
+            if (oldState[k] !== searchData[k]) {
+              changed = true;
+            }
+          }
+        });
+
+      if (changed) {
+        history.push({
+          hash: qs.stringify(newParams),
+        });
+      }
+    },
+    [history, oldState, location.hash],
+  );
+
+  return [current, setSearchData];
+};
+
+/**
+ * A hook to make it possible to switch disable mirroring the search block
+ * state to the window location. When using the internal state we "start from
+ * scratch", as it's intended to be used in the edit page.
+ */
+const useSearchBlockState = (uniqueId, isEditMode) => {
+  const [hashState, setHashState] = useHashState();
+  const [internalState, setInternalState] = React.useState({});
+
+  return isEditMode
+    ? [internalState, setInternalState]
+    : [hashState, setHashState];
+};
+
+// Simple compress/decompress the state in URL by replacing the lengthy string
+const deserializeQuery = (q) => {
+  return JSON.parse(q)?.map((kvp) => ({
+    ...kvp,
+    o: kvp.o.replace(/^paqo/, PAQO),
+  }));
+};
+const serializeQuery = (q) => {
+  return JSON.stringify(
+    q?.map((kvp) => ({ ...kvp, o: kvp.o.replace(PAQO, 'paqo') })),
+  );
+};
+
+const withSearch = (options) => (WrappedComponent) => {
+  const { inputDelay = 1000 } = options || {};
+
+  function WithSearch(props) {
+    const { data, id, editable = false } = props;
+
+    const [locationSearchData, setLocationSearchData] = useSearchBlockState(
+      id,
+      editable,
+    );
+
+    const urlQuery = locationSearchData.query
+      ? deserializeQuery(locationSearchData.query)
+      : [];
+    const urlSearchText =
+      locationSearchData.SearchableText ||
+      urlQuery.find(({ i }) => i === 'SearchableText')?.v ||
+      '';
+
+    // TODO: refactor, should use only useLocationStateManager()!!!
+    const [searchText, setSearchText] = React.useState(urlSearchText);
+    const configuredFacets =
+      data.facets?.map((facet) => facet?.field?.value) || [];
+    const multiFacets = data.facets
+      ?.filter((facet) => facet?.multiple)
+      .map((facet) => facet?.field?.value);
+    const [facets, setFacets] = React.useState(
+      Object.assign(
+        {},
+        ...urlQuery.map(({ i, v }) => ({ [i]: v })), // TODO: the 'o' should be kept. This would be a major refactoring of the facets
+
+        // support for simple filters like ?Subject=something
+        // TODO: since the move to hash params this is no longer working.
+        // We'd have to treat the location.search and manage it just like the
+        // hash, to support it. We can read it, but we'd have to reset it as
+        // well, so at that point what's the difference to the hash?
+        ...configuredFacets.map((f) =>
+          locationSearchData[f]
+            ? {
+                [f]:
+                  multiFacets.indexOf(f) > -1
+                    ? [locationSearchData[f]]
+                    : locationSearchData[f],
+              }
+            : {},
+        ),
+      ),
+    );
+
+    const [sortOn, setSortOn] = React.useState(data?.query?.sort_on);
+    const [sortOrder, setSortOrder] = React.useState(data?.query?.sort_order);
+
+    const [searchData, setSearchData] = React.useState(
+      getInitialState(data, facets, urlSearchText, id),
+    );
+
+    const timeoutRef = React.useRef();
+    const facetSettings = data?.facets;
+
+    const onTriggerSearch = React.useCallback(
+      (toSearchText, toSearchFacets, toSortOn, toSortOrder) => {
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(
+          () => {
+            const searchData = normalizeState({
+              id,
+              query: data.query || {},
+              facets: toSearchFacets || facets,
+              searchText: toSearchText,
+              sortOn: toSortOn ?? sortOn,
+              sortOrder: toSortOrder ?? sortOrder,
+              facetSettings,
+            });
+            if (toSearchFacets) setFacets(toSearchFacets);
+            // Added the check for '' here to reset it
+            if (toSortOn || toSortOn === '') setSortOn(toSortOn);
+            // Added the check for '' here to reset it
+            if (toSortOrder || toSortOrder === '') setSortOrder(toSortOrder);
+
+            if (toSortOn === '') {
+              delete searchData.sort_on;
+            }
+            if (toSortOrder === '') {
+              delete searchData.sort_order;
+            }
+            setSearchData(searchData);
+            setLocationSearchData(getSearchFields(searchData));
+          },
+          toSearchFacets ? inputDelay / 3 : inputDelay,
+        );
+      },
+      [
+        data.query,
+        facets,
+        id,
+        setLocationSearchData,
+        sortOn,
+        sortOrder,
+        facetSettings,
+      ],
+    );
+
+    const querystringResults = useSelector(
+      (state) => state.querystringsearch.subrequests,
+    );
+    const totalItems =
+      querystringResults[id]?.total || querystringResults[id]?.items?.length;
+
+    return (
+      <WrappedComponent
+        {...props}
+        searchData={searchData}
+        facets={facets}
+        setFacets={setFacets}
+        setSortOn={setSortOn}
+        setSortOrder={setSortOrder}
+        sortOn={sortOn}
+        sortOrder={sortOrder}
+        searchedText={urlSearchText}
+        searchText={searchText}
+        setSearchText={setSearchText}
+        onTriggerSearch={onTriggerSearch}
+        totalItems={totalItems}
+      />
+    );
+  }
+  WithSearch.displayName = `WithSearch(${getDisplayName(WrappedComponent)})`;
+
+  return WithSearch;
+};
+
+export default withSearch;

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
@@ -102,22 +102,16 @@ const LeftColumnFacets = (props) => {
                 isEditMode={isEditMode}
                 sortOn={sortOn}
                 sortOrder={sortOrder}
-                setSortOn={(sortOn) => {
-                  flushSync(() => {
-                    setSortOn(sortOn);
-                    onTriggerSearch(searchedText || '', facets, sortOn);
-                  });
-                }}
-                setSortOrder={(sortOrder) => {
-                  flushSync(() => {
-                    setSortOrder(sortOrder);
-                    onTriggerSearch(
-                      searchedText || '',
-                      facets,
-                      sortOn,
-                      sortOrder,
-                    );
-                  });
+                updateSort={({ sortOn, sortOrder }) => {
+                  setSortOn(sortOn);
+                  setSortOrder(sortOrder);
+                  onTriggerSearch(searchedText || '', facets, sortOn);
+                  onTriggerSearch(
+                    searchedText || '',
+                    facets,
+                    sortOn,
+                    sortOrder,
+                  );
                 }}
               />
             )}

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
@@ -76,22 +76,16 @@ const RightColumnFacets = (props) => {
                 isEditMode={isEditMode}
                 sortOn={sortOn}
                 sortOrder={sortOrder}
-                setSortOn={(sortOn) => {
-                  flushSync(() => {
-                    setSortOn(sortOn);
-                    onTriggerSearch(searchedText || '', facets, sortOn);
-                  });
-                }}
-                setSortOrder={(sortOrder) => {
-                  flushSync(() => {
-                    setSortOrder(sortOrder);
-                    onTriggerSearch(
-                      searchedText || '',
-                      facets,
-                      sortOn,
-                      sortOrder,
-                    );
-                  });
+                updateSort={({ sortOn, sortOrder }) => {
+                  setSortOn(sortOn);
+                  setSortOrder(sortOrder);
+                  onTriggerSearch(searchedText || '', facets, sortOn);
+                  onTriggerSearch(
+                    searchedText || '',
+                    facets,
+                    sortOn,
+                    sortOrder,
+                  );
                 }}
               />
             )}

--- a/src/customizations/volto/components/theme/Logo/Logo.jsx
+++ b/src/customizations/volto/components/theme/Logo/Logo.jsx
@@ -16,7 +16,7 @@ const Logo = () => {
   return (
     <UniversalLink href={settings.isMultilingual ? `/${lang}` : '/'}>
       {logoUrl && !logoUrl.includes('++resource++plone-logo.svg') ? (
-        <img class="nsw-header__logo" src={logoUrl} alt="" />
+        <img className="nsw-header__logo" src={logoUrl} alt="" />
       ) : (
         <>
           <svg


### PR DESCRIPTION
This PR changes the 'Sort on' of a search block to be hardcoded to the following options:

- Relevance (disabled 
- Most recent (sort_on: 'created', sort_order: 'descending')
- A-Z (sort_on: 'sortable_title', sort_order: 'ascending')

The visibility of the 'Sort on' can still be toggled off/ on

## Screenshots

<img width="1014" alt="Screenshot 2023-01-03 at 11 04 57 am" src="https://user-images.githubusercontent.com/30210785/210345444-d986e0ff-df79-45c7-abbf-96364015c316.png">

<img width="272" alt="Screenshot 2023-01-03 at 11 05 00 am" src="https://user-images.githubusercontent.com/30210785/210345448-bbb18c74-0d2b-4e4a-bdcb-20d38d0d7aac.png">
<img width="1054" alt="Screenshot 2023-01-03 at 11 05 05 am" src="https://user-images.githubusercontent.com/30210785/210345449-b1d7959a-1ccd-466d-8741-81ec98df8085.png">
<img width="1090" alt="Screenshot 2023-01-03 at 11 05 10 am" src="https://user-images.githubusercontent.com/30210785/210345452-e04a3dc0-8693-4034-8787-089fe92612e4.png">
