### PR TITLE
A11y fixes

### DIFF
--- a/src/customizations/volto/components/theme/Logo/Logo.jsx
+++ b/src/customizations/volto/components/theme/Logo/Logo.jsx
@@ -15,6 +15,7 @@ const Logo = () => {
 
   return (
     <UniversalLink href={settings.isMultilingual ? `/${lang}` : '/'}>
+      <span className="sr-only">{siteTitle}</span>
       {logoUrl && !logoUrl.includes('++resource++plone-logo.svg') ? (
         <img className="nsw-header__logo" src={logoUrl} alt="" />
       ) : (
@@ -47,7 +48,6 @@ const Logo = () => {
               fill="#D7153A"
             ></path>
           </svg>
-          <span className="sr-only">{siteTitle}</span>
         </>
       )}
     </UniversalLink>

--- a/src/customizations/volto/components/theme/SkipLinks/SkipLinks.jsx
+++ b/src/customizations/volto/components/theme/SkipLinks/SkipLinks.jsx
@@ -7,11 +7,11 @@ const messages = defineMessages({
     defaultMessage: 'Skip to links',
   },
   skipToNavigation: {
-    id: 'skiplink-main-content',
+    id: 'skiplink-navigation',
     defaultMessage: 'Skip to navigation',
   },
   skipToContent: {
-    id: 'skiplink-navigation',
+    id: 'skiplink-main-content',
     defaultMessage: 'Skip to content',
   },
 });
@@ -24,7 +24,7 @@ const SkipLinks = () => {
       className="nsw-skip"
       aria-label={intl.formatMessage(messages.skipLinksTitle)}
     >
-      <a className="skiplink" href="#main-navigation">
+      <a className="skiplink" href="#main-nav">
         <span>{intl.formatMessage(messages.skipToNavigation)}</span>
       </a>
       <a className="skiplink" href="#page-document">


### PR DESCRIPTION
This PR fixes:
- The site name not being set on the site logo, causing an in-accessible link
- The skip links were ordered incorrectly and did not point to valid elements