### PR TITLE
Spacing fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@kitconcept/volto-blocks-grid": "5.2.0",
     "@material-design-icons/svg": "0.14.2",
     "@mdi/svg": "7.1.96",
+    "html-react-parser": "3.0.15",
     "material-icons": "1.13.1",
     "nsw-design-system": "3.3.0",
     "react-color": "2.19.3",

--- a/src/customizations/volto-form-block/components/Field.jsx
+++ b/src/customizations/volto-form-block/components/Field.jsx
@@ -15,6 +15,7 @@ import TextareaWidget from './Widget/TextareaWidget';
 import TextWidget from './Widget/TextWidget';
 
 import config from '@plone/volto/registry';
+import parse from 'html-react-parser';
 
 const messages = defineMessages({
   select_a_value: {
@@ -234,14 +235,7 @@ const Field = (props) => {
             value={value}
           />
         ) : value?.data ? (
-          <>
-            <div
-              className="static-text"
-              dangerouslySetInnerHTML={{
-                __html: `<p style="height:0;">&nbsp;</p>${value.data}`,
-              }}
-            />
-          </>
+          parse(value.data)
         ) : (
           <br />
         ))}

--- a/src/customizations/volto/components/manage/Blocks/Description/View.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Description/View.jsx
@@ -1,0 +1,32 @@
+/**
+ * View title/description block.
+ * @module volto-slate/blocks/Title/TitleBlockView
+ *
+ * Changed `documentDescription` class to `nsw-intro`
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * View title block component.
+ * @class View
+ * @extends Component
+ */
+const TitleBlockView = ({ properties, metadata }) => {
+  return (
+    <p className="nsw-intro">{(metadata || properties)['description'] || ''}</p>
+  );
+};
+
+/**
+ * Property types.
+ * @property {Object} propTypes Property types.
+ * @static
+ */
+TitleBlockView.propTypes = {
+  properties: PropTypes.objectOf(PropTypes.any).isRequired,
+  metadata: PropTypes.objectOf(PropTypes.any),
+};
+
+export default TitleBlockView;

--- a/src/customizations/volto/components/manage/Blocks/Description/View.original.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Description/View.original.jsx
@@ -1,0 +1,32 @@
+/**
+ * View title/description block.
+ * @module volto-slate/blocks/Title/TitleBlockView
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * View title block component.
+ * @class View
+ * @extends Component
+ */
+const TitleBlockView = ({ properties, metadata }) => {
+  return (
+    <p className="documentDescription">
+      {(metadata || properties)['description'] || ''}
+    </p>
+  );
+};
+
+/**
+ * Property types.
+ * @property {Object} propTypes Property types.
+ * @static
+ */
+TitleBlockView.propTypes = {
+  properties: PropTypes.objectOf(PropTypes.any).isRequired,
+  metadata: PropTypes.objectOf(PropTypes.any),
+};
+
+export default TitleBlockView;

--- a/src/customizations/volto/components/theme/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/customizations/volto/components/theme/Breadcrumbs/Breadcrumbs.jsx
@@ -45,7 +45,7 @@ const Breadcrumbs = () => {
   }
 
   return (
-    <div className="nsw-container nsw-p-bottom-xs">
+    <div className="nsw-container">
       <nav
         aria-label={intl.formatMessage(messages.breadcrumbs)}
         className="nsw-breadcrumbs"

--- a/src/customizations/volto/components/theme/View/DefaultView.jsx
+++ b/src/customizations/volto/components/theme/View/DefaultView.jsx
@@ -166,68 +166,21 @@ const BlocksLayout = ({ content, location }) => {
   );
   const breadcrumbsHidden =
     location.pathname === '/' || siteDepth < breadcrumbStartDepth;
-  const hideTopPadding =
-    config.settings.fullWidthBlockTypes.includes(
+  const needExtraTopPadding =
+    !config.settings.fullWidthBlockTypes.includes(
       blocksData[blocksInLayout[0]]?.['@type'],
-    ) === breadcrumbsHidden;
+    ) && breadcrumbsHidden;
 
   return (
     <div id="page-document">
-      <div className="nsw-layout">
-        <div
-          className="nsw-layout__main"
-          style={{
-            // XOR operation, not sure of a nicer way of doing it in JS
-            paddingBlockStart: hideTopPadding ? 0 : null,
-            paddingBlockEnd: config.settings.fullWidthBlockTypes.includes(
-              blocksData[blocksInLayout.length]?.['@type'],
-            )
-              ? '0'
-              : null,
-          }}
-        >
-          {groupedBlocksLayout.map((blockIdOrGroup, index) => {
-            if (blockIdOrGroup instanceof Array) {
-              const blockGroup = blockIdOrGroup; // Rename it just to make the code more readable
-              if (blocksNeedSections) {
-                const blockWithSectionData = blocksData?.[blockGroup[0]];
-                const sectionColour = getSectionColour(blockWithSectionData);
-                if (_blockNeedsSection(blockWithSectionData)) {
-                  return (
-                    <Section
-                      key={index}
-                      padding={blockWithSectionData.sectionspacing}
-                      isBox={blockWithSectionData.sectionType === 'box'}
-                      colour={sectionColour}
-                      shouldInvert={blockWithSectionData.sectioninvert}
-                    >
-                      {blockGroup.map((blockId) => {
-                        // Copy pasted from below. Should really make this a function!
-                        const blockData = blocksData?.[blockId];
-                        const blockType = blockData?.['@type'];
-                        const Block =
-                          config.blocks.blocksConfig[blockType]?.['view'] ||
-                          null;
-                        return Block !== null ? (
-                          <Block
-                            key={blockId}
-                            id={blockId}
-                            properties={content}
-                            data={blocksData[blockId]}
-                            path={getBaseUrl(location?.pathname || '')}
-                          />
-                        ) : (
-                          <div key={blockId}>
-                            {intl.formatMessage(messages.unknownBlock, {
-                              block: blockType,
-                            })}
-                          </div>
-                        );
-                      })}
-                    </Section>
-                  );
-                }
-
+      <div className={cx({ 'nsw-p-top-md': needExtraTopPadding })}>
+        {groupedBlocksLayout.map((blockIdOrGroup, index) => {
+          if (blockIdOrGroup instanceof Array) {
+            const blockGroup = blockIdOrGroup; // Rename it just to make the code more readable
+            if (blocksNeedSections) {
+              const blockWithSectionData = blocksData?.[blockGroup[0]];
+              const sectionColour = getSectionColour(blockWithSectionData);
+              if (_blockNeedsSection(blockWithSectionData)) {
                 return (
                   <Section
                     key={index}
@@ -261,12 +214,14 @@ const BlocksLayout = ({ content, location }) => {
                   </Section>
                 );
               }
+
               return (
-                <div
-                  key={`blockgroup-${index}`}
-                  className={cx('nsw-container', {
-                    'nsw-p-bottom-md': index + 1 === groupedBlocksLayout.length,
-                  })}
+                <Section
+                  key={index}
+                  padding={blockWithSectionData.sectionspacing}
+                  isBox={blockWithSectionData.sectionType === 'box'}
+                  colour={sectionColour}
+                  shouldInvert={blockWithSectionData.sectioninvert}
                 >
                   {blockGroup.map((blockId) => {
                     // Copy pasted from below. Should really make this a function!
@@ -290,50 +245,80 @@ const BlocksLayout = ({ content, location }) => {
                       </div>
                     );
                   })}
-                </div>
+                </Section>
               );
             }
-            const blockId = blockIdOrGroup; // Rename it just to make the code more readable
-            const blockData = blocksData?.[blockId];
-            const blockType = blockData?.['@type'];
-            const Block =
-              config.blocks.blocksConfig[blockType]?.['view'] || null;
-            if (Block === null) {
-              return (
-                <div key={blockId}>
-                  {intl.formatMessage(messages.unknownBlock, {
-                    block: blockType,
-                  })}
-                </div>
-              );
-            }
-            return config.settings.fullWidthBlockTypes.includes(blockType) ? (
+            return (
+              <div
+                key={`blockgroup-${index}`}
+                className={cx('nsw-container', {
+                  'nsw-p-bottom-md': index + 1 === groupedBlocksLayout.length,
+                })}
+              >
+                {blockGroup.map((blockId) => {
+                  // Copy pasted from below. Should really make this a function!
+                  const blockData = blocksData?.[blockId];
+                  const blockType = blockData?.['@type'];
+                  const Block =
+                    config.blocks.blocksConfig[blockType]?.['view'] || null;
+                  return Block !== null ? (
+                    <Block
+                      key={blockId}
+                      id={blockId}
+                      properties={content}
+                      data={blocksData[blockId]}
+                      path={getBaseUrl(location?.pathname || '')}
+                    />
+                  ) : (
+                    <div key={blockId}>
+                      {intl.formatMessage(messages.unknownBlock, {
+                        block: blockType,
+                      })}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          }
+          const blockId = blockIdOrGroup; // Rename it just to make the code more readable
+          const blockData = blocksData?.[blockId];
+          const blockType = blockData?.['@type'];
+          const Block = config.blocks.blocksConfig[blockType]?.['view'] || null;
+          if (Block === null) {
+            return (
+              <div key={blockId}>
+                {intl.formatMessage(messages.unknownBlock, {
+                  block: blockType,
+                })}
+              </div>
+            );
+          }
+          return config.settings.fullWidthBlockTypes.includes(blockType) ? (
+            <Block
+              key={blockId}
+              id={blockId}
+              properties={content}
+              data={blocksData[blockId]}
+              path={getBaseUrl(location?.pathname || '')}
+            />
+          ) : (
+            <div
+              key={blockId}
+              className={cx('nsw-container', {
+                'nsw-p-bottom-md':
+                  index + 1 === groupedBlocksLayout.length &&
+                  blockType !== 'nsw_section',
+              })}
+            >
               <Block
-                key={blockId}
                 id={blockId}
                 properties={content}
                 data={blocksData[blockId]}
                 path={getBaseUrl(location?.pathname || '')}
               />
-            ) : (
-              <div
-                key={blockId}
-                className={cx('nsw-container', {
-                  'nsw-p-bottom-md':
-                    index + 1 === groupedBlocksLayout.length &&
-                    blockType !== 'nsw_section',
-                })}
-              >
-                <Block
-                  id={blockId}
-                  properties={content}
-                  data={blocksData[blockId]}
-                  path={getBaseUrl(location?.pathname || '')}
-                />
-              </div>
-            );
-          })}
-        </div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/customizations/volto/components/theme/View/DefaultView.jsx
+++ b/src/customizations/volto/components/theme/View/DefaultView.jsx
@@ -331,7 +331,7 @@ const PloneClassicLayout = ({ content }) => {
         <div className="nsw-layout__main">
           <h1 className="documentFirstHeading">{content.title}</h1>
           {content.description && (
-            <p className="documentDescription">{content.description}</p>
+            <p className="nsw-summary">{content.description}</p>
           )}
           {content.image && (
             <Image

--- a/src/customizations/volto/components/theme/View/EventView.jsx
+++ b/src/customizations/volto/components/theme/View/EventView.jsx
@@ -14,7 +14,7 @@ const EventTextfieldView = ({ content }) => (
   <React.Fragment>
     {content.title && <h1 className="documentFirstHeading">{content.title}</h1>}
     {content.description && (
-      <p className="documentDescription">{content.description}</p>
+      <p className="nsw-intro">{content.description}</p>
     )}
     {content.image && (
       <Image

--- a/src/customizations/volto/components/theme/View/FileView.jsx
+++ b/src/customizations/volto/components/theme/View/FileView.jsx
@@ -12,7 +12,7 @@ const FileView = ({ content }) => (
           {content.subtitle && ` - ${content.subtitle}`}
         </h1>
         {content.description && (
-          <p className="documentDescription">{content.description}</p>
+          <p className="nsw-intro">{content.description}</p>
         )}
         {content.file?.download && (
           <a href={flattenToAppURL(content.file.download)}>

--- a/src/customizations/volto/components/theme/View/ImageView.jsx
+++ b/src/customizations/volto/components/theme/View/ImageView.jsx
@@ -25,7 +25,7 @@ const ImageView = ({ content }) => (
           {content.subtitle && ` - ${content.subtitle}`}
         </h1>
         {content.description && (
-          <p className="documentDescription">{content.description}</p>
+          <p className="nsw-intro">{content.description}</p>
         )}
         {content?.image?.download && (
           <a href={flattenToAppURL(content.image.download)}>

--- a/src/customizations/volto/components/theme/View/NewsItemView.jsx
+++ b/src/customizations/volto/components/theme/View/NewsItemView.jsx
@@ -35,7 +35,7 @@ const NewsItemView = ({ content }) => {
                 </h1>
               )}
               {content.description && (
-                <p className="documentDescription">{content.description}</p>
+                <p className="nsw-intro">{content.description}</p>
               )}
               {content.image && (
                 <Image

--- a/src/styles/view.scss
+++ b/src/styles/view.scss
@@ -17,3 +17,8 @@ mark {
   font-weight: bold;
   background-color: transparent;
 }
+
+.nsw-breadcrumbs {
+  margin-top: initial;
+  @extend .nsw-p-y-sm;
+}


### PR DESCRIPTION
This PR fixes the following spacing issues:

- Most pages having a horizontal scroll
- Breadcrumbs above full-width blocks are not evenly spaced
- Titles in the form block have too much space