### PR TITLE
Add environment variable for displaying self sign-up

### DIFF
--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -11,7 +11,11 @@ export const updateSettingsConfig = (config) => {
     ...(config.settings.fullWidthBlockTypes || []),
   ];
 
-  config.settings.showTags = false
+  config.settings.showTags = false;
+  config.settings.showSelfRegistration =
+    process?.env?.['RAZZLE_ENABLE_SELF_REGISTRATION'] === 'true' ||
+    (typeof window !== 'undefined' &&
+      window.env['RAZZLE_ENABLE_SELF_REGISTRATION'] === 'true');
 };
 
 export default updateSettingsConfig;


### PR DESCRIPTION
This PR adds an environment variable to allow the 'Register' link to be displayed on the login page.