### PR TITLE
Use existing breadcrumbs for site depth rather than backend call

### DIFF
--- a/src/customizations/volto/components/theme/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/customizations/volto/components/theme/Breadcrumbs/Breadcrumbs.jsx
@@ -26,9 +26,7 @@ const Breadcrumbs = () => {
   const breadcrumbStartDepth = useSelector(
     (state) => state.nswSiteSettings?.data?.breadcrumb_start_depth,
   );
-  const siteDepth = useSelector(
-    (state) => state.nswSiteSettings?.data?.site_depth,
-  );
+  const siteDepth = items.length + 1;
 
   useEffect(() => {
     if (!hasApiExpander('breadcrumbs', getBaseUrl(pathname))) {

--- a/src/customizations/volto/components/theme/View/DefaultView.jsx
+++ b/src/customizations/volto/components/theme/View/DefaultView.jsx
@@ -162,7 +162,7 @@ const BlocksLayout = ({ content, location }) => {
     (state) => state.nswSiteSettings?.data?.breadcrumb_start_depth,
   );
   const siteDepth = useSelector(
-    (state) => state.nswSiteSettings?.data?.site_depth,
+    (state) => state.breadcrumbs?.items?.length + 1,
   );
   const breadcrumbsHidden =
     location.pathname === '/' || siteDepth < breadcrumbStartDepth;


### PR DESCRIPTION
This avoids having to rely on the `site_depth` option for breadcrumb logic