### PR TITLE
Image scaling

### DIFF
--- a/src/components/Blocks/Card/Edit.jsx
+++ b/src/components/Blocks/Card/Edit.jsx
@@ -113,6 +113,7 @@ function CardEditDisplay({ data, id, onChangeBlock, selected, ...props }) {
     <div>
       <Card
         {...props}
+        data={data}
         {...data}
         title={
           <TextLineEdit

--- a/src/components/Blocks/Card/Edit.jsx
+++ b/src/components/Blocks/Card/Edit.jsx
@@ -55,7 +55,7 @@ function Validation({ messages }) {
   );
 }
 
-function CardEditDisplay({ data, id, onChangeBlock, selected }) {
+function CardEditDisplay({ data, id, onChangeBlock, selected, ...props }) {
   const dispatch = useDispatch();
   const { pathname } = useLocation();
   const contentCreationAction = useSelector(
@@ -112,6 +112,7 @@ function CardEditDisplay({ data, id, onChangeBlock, selected }) {
   return (
     <div>
       <Card
+        {...props}
         {...data}
         title={
           <TextLineEdit
@@ -156,6 +157,7 @@ function CardEditDisplay({ data, id, onChangeBlock, selected }) {
               className="nsw-card__image"
               onChange={imageUpload}
               blockSelected={selected}
+              columns={props.columns}
             />
           ) : null
         }

--- a/src/components/Blocks/Card/View.jsx
+++ b/src/components/Blocks/Card/View.jsx
@@ -3,7 +3,7 @@ import { getHref } from 'nsw-design-system-plone6/components/Blocks/Card/helpers
 import { Card } from 'nsw-design-system-plone6/components/Components/Card';
 
 // TODO: Support adding alt text to images
-export function CardView({ data, isEditMode }) {
+export function CardView({ data, isEditMode, ...props }) {
   let href = getHref(data);
   if (isInternalURL(href)) {
     href = flattenToAppURL(href);
@@ -17,6 +17,7 @@ export function CardView({ data, isEditMode }) {
 
   return (
     <Card
+      {...props}
       {...data}
       description={description}
       href={href}

--- a/src/components/Blocks/Card/View.jsx
+++ b/src/components/Blocks/Card/View.jsx
@@ -18,6 +18,7 @@ export function CardView({ data, isEditMode, ...props }) {
   return (
     <Card
       {...props}
+      data={data}
       {...data}
       description={description}
       href={href}

--- a/src/components/Blocks/ContentBlock/Edit.jsx
+++ b/src/components/Blocks/ContentBlock/Edit.jsx
@@ -110,6 +110,7 @@ function ContentBlockEditDisplay({ data, id, onChangeBlock, ...props }) {
               className="nsw-content-block__image"
               onChange={imageUpload}
               blockSelected={props.selected}
+              columns={props.columns}
             />
           ) : null
         }

--- a/src/components/Blocks/ContentBlock/Edit.jsx
+++ b/src/components/Blocks/ContentBlock/Edit.jsx
@@ -67,6 +67,7 @@ function ContentBlockEditDisplay({ data, id, onChangeBlock, ...props }) {
   return (
     <>
       <ContentBlock
+        data={data}
         {...data}
         title={
           <TextLineEdit

--- a/src/components/Blocks/ContentBlock/View.jsx
+++ b/src/components/Blocks/ContentBlock/View.jsx
@@ -10,6 +10,7 @@ export function ContentBlockView({ data, ...props }) {
     : data.description;
   return (
     <ContentBlock
+      data={data}
       {...data}
       description={description}
       viewMoreUrl={getViewMore(data)}

--- a/src/components/Blocks/ContentBlock/View.jsx
+++ b/src/components/Blocks/ContentBlock/View.jsx
@@ -2,7 +2,7 @@ import { ContentBlock } from 'nsw-design-system-plone6/components/Components/Con
 import { getLinks, getViewMore } from './helpers';
 
 // TODO: Allow adding alt text to images
-export function ContentBlockView({ data }) {
+export function ContentBlockView({ data, ...props }) {
   const description = ['<p></p>', '<p><br/></p>'].includes(
     data.description?.data,
   )
@@ -15,6 +15,7 @@ export function ContentBlockView({ data }) {
       viewMoreUrl={getViewMore(data)}
       links={getLinks(data)}
       image={data.image ? `${data.image}/@@images/image` : null}
+      columns={props.columns}
     />
   );
 }

--- a/src/components/Blocks/Listing/CardListing.jsx
+++ b/src/components/Blocks/Listing/CardListing.jsx
@@ -32,6 +32,7 @@ export function CardListing({ items, isEditMode, ...data }) {
           >
             <Card
               {...data}
+              data={item}
               {...item}
               description={!data.showDescription ? null : item.description}
               image={image}

--- a/src/components/Components/Card.jsx
+++ b/src/components/Components/Card.jsx
@@ -31,6 +31,13 @@ export function DefaultImage({ className }) {
   );
 }
 
+const columnsImageSizeMapping = {
+  1: 'great',
+  2: 'teaser',
+  3: 'preview',
+  4: 'preview',
+};
+
 // TODO: Support adding alt text to images
 export function Card({
   title,
@@ -45,9 +52,17 @@ export function Card({
   colour,
   shouldHighlight,
   isEditMode,
+  columns,
 }) {
   const linkTitle = title || href;
   const cleanDate = date === 'None' ? null : date;
+
+  const imageString =
+    typeof image === 'string'
+      ? columns
+        ? `${image}/${columnsImageSizeMapping[columns]}`
+        : image
+      : `data:${image['content-type']};base64,${image.data}`;
 
   return (
     <div
@@ -64,18 +79,7 @@ export function Card({
           image
         ) : (
           <div className="nsw-card__image">
-            {image ? (
-              <img
-                src={
-                  typeof image === 'string'
-                    ? image
-                    : `data:${image['content-type']};base64,${image.data}`
-                }
-                alt=""
-              />
-            ) : (
-              <DefaultImage />
-            )}
+            {image ? <img src={imageString} alt="" /> : <DefaultImage />}
           </div>
         )
       ) : null}

--- a/src/components/Components/Card.jsx
+++ b/src/components/Components/Card.jsx
@@ -1,4 +1,5 @@
 import { FormattedDate, Icon, UniversalLink } from '@plone/volto/components';
+import config from '@plone/volto/registry';
 import cx from 'classnames';
 import { isValidElement } from 'react';
 
@@ -31,13 +32,6 @@ export function DefaultImage({ className }) {
   );
 }
 
-const columnsImageSizeMapping = {
-  1: 'great',
-  2: 'teaser',
-  3: 'preview',
-  4: 'preview',
-};
-
 // TODO: Support adding alt text to images
 export function Card({
   title,
@@ -52,10 +46,14 @@ export function Card({
   colour,
   shouldHighlight,
   isEditMode,
+  data, // Might  be extra data we want about the block
   columns,
 }) {
   const linkTitle = title || href;
   const cleanDate = date === 'None' ? null : date;
+
+  const columnsImageSizeMapping =
+    config.blocks.blocksConfig[data['@type']].columnsImageSizeMapping;
 
   const imageString =
     typeof image === 'string'

--- a/src/components/Components/Card.jsx
+++ b/src/components/Components/Card.jsx
@@ -53,14 +53,17 @@ export function Card({
   const cleanDate = date === 'None' ? null : date;
 
   const columnsImageSizeMapping =
-    config.blocks.blocksConfig[data['@type']].columnsImageSizeMapping;
+    config.blocks.blocksConfig[data['@type']]?.columnsImageSizeMapping;
 
-  const imageString =
-    typeof image === 'string'
-      ? columns
-        ? `${image}/${columnsImageSizeMapping[columns]}`
-        : image
-      : `data:${image['content-type']};base64,${image.data}`;
+  let imageString = undefined;
+  if (image) {
+    imageString =
+      typeof image === 'string'
+        ? columns && columnsImageSizeMapping
+          ? `${image}/${columnsImageSizeMapping[columns]}`
+          : image
+        : `data:${image['content-type']};base64,${image.data}`;
+  }
 
   return (
     <div

--- a/src/components/Components/ContentBlock.jsx
+++ b/src/components/Components/ContentBlock.jsx
@@ -1,4 +1,5 @@
 import { UniversalLink } from '@plone/volto/components';
+import config from '@plone/volto/registry';
 import PropTypes from 'prop-types';
 import { isValidElement } from 'react';
 
@@ -38,13 +39,6 @@ ContentBlock.propTypes = {
   columns: PropTypes.number,
 };
 
-const columnsImageSizeMapping = {
-  1: 'great',
-  2: 'teaser',
-  3: 'preview',
-  4: 'preview',
-};
-
 // TODO: Support adding alt text to images
 export function ContentBlock({
   title,
@@ -56,15 +50,18 @@ export function ContentBlock({
   imagePosition,
   showViewMoreLink,
   isEditMode,
+  data,
   columns,
 }) {
+  const columnsImageSizeMapping =
+    config.blocks.blocksConfig[data['@type']].columnsImageSizeMapping;
+
   const imageString =
     typeof image === 'string'
       ? columns
         ? `${image}/${columnsImageSizeMapping[columns]}`
         : image
       : `data:${image['content-type']};base64,${image.data}`;
-
 
   return (
     <div className="nsw-content-block__content">

--- a/src/components/Components/ContentBlock.jsx
+++ b/src/components/Components/ContentBlock.jsx
@@ -54,14 +54,17 @@ export function ContentBlock({
   columns,
 }) {
   const columnsImageSizeMapping =
-    config.blocks.blocksConfig[data['@type']].columnsImageSizeMapping;
+    config.blocks.blocksConfig[data['@type']]?.columnsImageSizeMapping;
 
-  const imageString =
-    typeof image === 'string'
-      ? columns
-        ? `${image}/${columnsImageSizeMapping[columns]}`
-        : image
-      : `data:${image['content-type']};base64,${image.data}`;
+  let imageString = undefined;
+  if (image) {
+    imageString =
+      typeof image === 'string'
+        ? columns && columnsImageSizeMapping
+          ? `${image}/${columnsImageSizeMapping[columns]}`
+          : image
+        : `data:${image['content-type']};base64,${image.data}`;
+  }
 
   return (
     <div className="nsw-content-block__content">

--- a/src/components/Components/ContentBlock.jsx
+++ b/src/components/Components/ContentBlock.jsx
@@ -35,6 +35,14 @@ ContentBlock.propTypes = {
   imageIsIcon: PropTypes.bool,
   showViewMoreLink: PropTypes.bool,
   isEditMode: PropTypes.bool,
+  columns: PropTypes.number,
+};
+
+const columnsImageSizeMapping = {
+  1: 'great',
+  2: 'teaser',
+  3: 'preview',
+  4: 'preview',
 };
 
 // TODO: Support adding alt text to images
@@ -48,7 +56,16 @@ export function ContentBlock({
   imagePosition,
   showViewMoreLink,
   isEditMode,
+  columns,
 }) {
+  const imageString =
+    typeof image === 'string'
+      ? columns
+        ? `${image}/${columnsImageSizeMapping[columns]}`
+        : image
+      : `data:${image['content-type']};base64,${image.data}`;
+
+
   return (
     <div className="nsw-content-block__content">
       {imagePosition !== 'hidden' ? (
@@ -59,25 +76,10 @@ export function ContentBlock({
             <div className="nsw-content-block__image">
               {imageIsIcon ? (
                 <div className="nsw-content-block__icon">
-                  <img
-                    src={
-                      typeof image === 'string'
-                        ? image
-                        : `data:${image['content-type']};base64,${image.data}`
-                    }
-                    alt=""
-                  />
+                  <img src={imageString} alt="" />
                 </div>
               ) : (
-                <img
-                  className="nsw-content-block__image"
-                  src={
-                    typeof image === 'string'
-                      ? image
-                      : `data:${image['content-type']};base64,${image.data}`
-                  }
-                  alt=""
-                />
+                <img src={imageString} alt="" />
               )}
             </div>
           )

--- a/src/components/Widgets/ImagePickerWidget.jsx
+++ b/src/components/Widgets/ImagePickerWidget.jsx
@@ -9,11 +9,19 @@ const messages = defineMessages({
   },
 });
 
+const columnsImageSizeMapping = {
+  1: 'great',
+  2: 'teaser',
+  3: 'preview',
+  4: 'preview',
+};
+
 export function ImagePickerWidget({
   image,
   className,
   onChange,
   blockSelected,
+  columns,
 }) {
   const intl = useIntl();
 
@@ -25,6 +33,10 @@ export function ImagePickerWidget({
     }
   }
 
+  const imageString = columns
+    ? `${image}/${columnsImageSizeMapping[columns]}`
+    : image;
+
   return (
     <>
       {/* TODO: Card edit block image field styling is all inline */}
@@ -34,7 +46,9 @@ export function ImagePickerWidget({
             {intl.formatMessage(messages.addImage)}
           </span>
           {image ? (
-            <img className={className} src={image} alt="" />
+            <div className={className}>
+              <img src={imageString} alt="" />
+            </div>
           ) : (
             <DefaultImage />
           )}

--- a/src/config/blocks/blockDefinitions.js
+++ b/src/config/blocks/blockDefinitions.js
@@ -31,6 +31,12 @@ export const nswBlocks = [
     blockSchema: Components.singleCardSchema,
     restricted: true,
     mostUsed: true,
+    columnsImageSizeMapping: {
+      1: 'great',
+      2: 'teaser',
+      3: 'preview',
+      4: 'preview',
+    },
     security: {
       addPermission: [],
       view: [],
@@ -46,6 +52,12 @@ export const nswBlocks = [
     blockSchema: Components.contentBlockSchema,
     restricted: true,
     mostUsed: false,
+    columnsImageSizeMapping: {
+      1: 'great',
+      2: 'teaser',
+      3: 'preview',
+      4: 'preview',
+    },
     security: {
       addPermission: [],
       view: [],

--- a/src/config/blocks/blocks.js
+++ b/src/config/blocks/blocks.js
@@ -75,6 +75,7 @@ export function applyBlocks(config) {
 
   // TODO: Write a more generic way of altering block definitions of scale mapping for built-in blocks
   config.blocks.blocksConfig['image'].columnsImageSizeMapping = {
+    fullWidth: 'great',
     '90': 'great',
     '80': 'larger',
     '70': 'larger',

--- a/src/config/blocks/blocks.js
+++ b/src/config/blocks/blocks.js
@@ -73,6 +73,17 @@ export function applyBlocks(config) {
     };
   }
 
+  // TODO: Write a more generic way of altering block definitions of scale mapping for built-in blocks
+  config.blocks.blocksConfig['image'].columnsImageSizeMapping = {
+    '90': 'great',
+    '80': 'larger',
+    '70': 'larger',
+    '60': 'large',
+    '50': 'teaser',
+    '40': 'teaser',
+    '30': 'preview',
+  };
+
   removeFieldsFromBlock(config, 'accordion', ['right_arrows', 'non_exclusive']);
   removeVariationsFromBlock(config, 'toc', ['horizontalMenu']);
   removeUnwantedBlocks(config);

--- a/src/customizations/@kitconcept/volto-blocks-grid/components/Grid/Edit.jsx
+++ b/src/customizations/@kitconcept/volto-blocks-grid/components/Grid/Edit.jsx
@@ -450,6 +450,7 @@ class EditGrid extends Component {
                                         }}
                                         data={this.props.data.columns[index]}
                                         blocksConfig={blocksConfig}
+                                        columns={data?.columns.length}
                                       />
                                     ) : (
                                       <div className="uber-grid-default-item">

--- a/src/customizations/@kitconcept/volto-blocks-grid/components/Grid/View.jsx
+++ b/src/customizations/@kitconcept/volto-blocks-grid/components/Grid/View.jsx
@@ -21,6 +21,7 @@ const ViewGrid = ({ data, path }) => {
               type={column['@type']}
               data={column}
               path={path}
+              columns={data?.columns.length}
             />
           </div>
         ))}

--- a/src/customizations/volto/components/manage/Blocks/HeroImageLeft/View.jsx
+++ b/src/customizations/volto/components/manage/Blocks/HeroImageLeft/View.jsx
@@ -4,7 +4,7 @@ import Hero from 'nsw-design-system-plone6/components/Components/Hero';
 
 const View = ({ data, ...props }) => {
   const imageUrl = data.url
-    ? `${flattenToAppURL(data?.url)}/@@images/image`
+    ? `${flattenToAppURL(data?.url)}/@@images/image/great`
     : null;
   const linkUrl = data.linkHref
     ? `${flattenToAppURL(data.linkHref[0]?.['@id'])}`

--- a/src/customizations/volto/components/manage/Blocks/Image/Body.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Image/Body.jsx
@@ -20,8 +20,10 @@ export const Body = ({ data, href }) => {
 
   function withImageScale(url, size) {
     // Resort to full width if not set
-    const sizeToUse = size ? size : '90';
-    return columnsImageSizeMapping?.[sizeToUse];
+    const sizeToUse = size ? size : 'fullWidth';
+    // Fallback for missing mapping
+    const scaleSize = columnsImageSizeMapping?.[sizeToUse] || 'great';
+    return `${url}/${scaleSize}`;
   }
 
   const baseImageString = isInternalURL(data.url)
@@ -38,8 +40,6 @@ export const Body = ({ data, href }) => {
     : data.url;
 
   const imageString = withImageScale(baseImageString, data.size);
-
-      debugger;
 
   return (
     <figure

--- a/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
@@ -7,7 +7,7 @@ import { Message } from 'semantic-ui-react';
 const Body = ({ data, isEditMode, isSelectedInEditMode }) => {
   let placeholder = data.preview_image
     ? isInternalURL(data.preview_image)
-      ? `${flattenToAppURL(data.preview_image)}/@@images/image`
+      ? `${flattenToAppURL(data.preview_image)}/@@images/image/large`
       : data.preview_image
     : null;
 


### PR DESCRIPTION
This PR fixes image scaling for the following:

- Hero images
- Card grid images
- Content block grid images
- Image blocks in both full-width mode and when using positioning + sizing
- Video block image previews

Where appropriate, the images have been converted to use `<picture>` to ensure the quality is retained across screen width breakpoint sizes. The maximum width of the column is 1200px and so the `great` scale has been used as the 'maximum' quality.