### PR TITLE
Fix logo indentation

### DIFF
--- a/src/customizations/volto/components/theme/Logo/Logo.jsx
+++ b/src/customizations/volto/components/theme/Logo/Logo.jsx
@@ -15,7 +15,6 @@ const Logo = () => {
 
   return (
     <UniversalLink href={settings.isMultilingual ? `/${lang}` : '/'}>
-      <span className="sr-only">{siteTitle}</span>
       {logoUrl && !logoUrl.includes('++resource++plone-logo.svg') ? (
         <img className="nsw-header__logo" src={logoUrl} alt="" />
       ) : (
@@ -50,6 +49,7 @@ const Logo = () => {
           </svg>
         </>
       )}
+      <span className="sr-only">{siteTitle}</span>
     </UniversalLink>
   );
 };


### PR DESCRIPTION
The `sr-only` text was triggering a CSS rule to increase spacing. Moving the `sr-only` text to after the logo fixes this