### PR TITLE
Track volto-form-block developoment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/addons/volto-form-block"]
+	path = src/addons/volto-form-block
+	url = git@github.com:pretagov/volto-form-block.git

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,14 @@ start-backend-docker:		## Starts a Docker-based backend
 	@echo "$(GREEN)==> Start Docker-based Plone Backend$(RESET)"
 	docker run -it --rm --name=backend -p 8080:8080 -e SITE=Plone -e ADDONS='$(KGS)' $(DOCKER_IMAGE)
 
+.PHONY: preinstall
+preinstall: ## Preinstall task, checks if missdev (mrs-developer) is present and runs it
+	if [ -f $$(pwd)/mrs.developer.json ]; then make develop; fi
+
+.PHONY: develop
+develop: ## Runs missdev in the local project (mrs.developer.json should be present)
+	npx -p mrs-developer missdev --config=jsconfig.json --output=addons --fetch-https
+
 .PHONY: help
 help:		## Show this help.
 	@echo -e "$$(grep -hE '^\S+:.*##' $(MAKEFILE_LIST) | sed -e 's/:.*##\s*/:/' -e 's/^\(.\+\):\(.*\)/\\x1b[36m\1\\x1b[m:\2/' | column -c2 -t -s :)"

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "paths": {
+            "volto-form-block": [
+                "addons/volto-form-block/src"
+            ]
+        },
+        "baseUrl": "src"
+    },
+    "exclude": [
+        "node_modules",
+        "omelette",
+        "build",
+        "**/node_modules",
+        "dist"
+    ]
+}

--- a/mrs.developer.json
+++ b/mrs.developer.json
@@ -1,0 +1,9 @@
+{
+  "volto-form-block": {
+    "url": "https://github.com/pretagov/volto-form-block.git",
+    "package": "volto-form-block",
+    "path": "src",
+    "branch": "deploy",
+    "develop": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "material-icons": "1.13.6",
     "nsw-design-system": "3.5.1",
     "react-color": "2.19.3",
-    "volto-form-block": "3.0.1",
+    "volto-form-block": "file:./src/addons/volto-form-block",
     "volto-google-analytics": "2.0.0",
     "volto-siteinfo": "1.0.2",
     "volto-subblocks": "2.0.0",


### PR DESCRIPTION
This PR adds volto-form-block as a development dependency. While we have been reliant on a specific branch of this addon for a while, this dependency was tracked external to this repo. For this to work, you need to ensure the submodule is added to your theme's workspaces. E.g.:

```json
"workspaces": [
    "src/addons/nsw-design-system-plone6",
    "src/addons/nsw-design-system-plone6/src/addons/volto-form-block"
  ],
```