### PR TITLE
Add default values for "Display value as" of a yes/ no field with a radio widget

### DIFF
--- a/src/customizations/volto-form-block/components/Field.jsx
+++ b/src/customizations/volto-form-block/components/Field.jsx
@@ -54,7 +54,7 @@ const Field = (props) => {
   } = props;
   let { value } = props;
   // A value of `null` is a touched field with no value
-  if (props.default_value && value !== null && value === undefined) {
+  if (typeof props.default_value === "boolean" && value !== null && value === undefined) {
     value = props.default_value;
   }
   const intl = useIntl();


### PR DESCRIPTION
This ensures that the behaviour is consistent between what is seen on the form and what is seen in the summary email without having to configure anything