### PR TITLE
Update format for NSW version in footer to include the DDS version

### DIFF
--- a/src/components/DesignSystemVersionInformation.jsx
+++ b/src/components/DesignSystemVersionInformation.jsx
@@ -1,0 +1,53 @@
+import { FormattedMessage } from 'react-intl';
+
+import nswPackageJson from 'nsw-design-system/package.json';
+
+export function DesignSystemVersionInformation() {
+  let designSystemVersion = nswPackageJson?.version;
+  try {
+    designSystemVersion = designSystemVersion.split('.').slice(0, 2).join('.');
+  } catch {
+    console.warn(
+      'Failed to fetch valid design system version: ',
+      designSystemVersion,
+    );
+  }
+
+  const ploneVersion = 'Plone 6';
+
+  if (designSystemVersion && !ploneVersion) {
+    return (
+      <FormattedMessage
+        id="NSW Built with - DDS only"
+        defaultMessage="NSW DDS {ddsVersion}"
+        values={{
+          ddsVersion: designSystemVersion,
+        }}
+      />
+    );
+  } else if (!designSystemVersion && ploneVersion) {
+    return (
+      <FormattedMessage
+        id="NSW Built with - plone only"
+        defaultMessage="NSW DDS {ploneVersion}"
+        values={{
+          ploneVersion: ploneVersion,
+        }}
+      />
+    );
+  } else if (designSystemVersion && ploneVersion) {
+    return (
+      <FormattedMessage
+        id="NSW Built with - DDS and Plone"
+        defaultMessage="NSW DDS {ddsVersion} {ploneVersion}"
+        values={{
+          ddsVersion: designSystemVersion,
+          ploneVersion: ploneVersion,
+        }}
+      />
+    );
+  }
+  return (
+    <FormattedMessage id="NSW Built with - Fallback" defaultMessage="NSW DDS" />
+  );
+}

--- a/src/components/DesignSystemVersionInformation.jsx
+++ b/src/components/DesignSystemVersionInformation.jsx
@@ -13,41 +13,22 @@ export function DesignSystemVersionInformation() {
     );
   }
 
-  const ploneVersion = 'Plone 6';
-
-  if (designSystemVersion && !ploneVersion) {
-    return (
-      <FormattedMessage
-        id="NSW Built with - DDS only"
-        defaultMessage="NSW DDS {ddsVersion}"
-        values={{
-          ddsVersion: designSystemVersion,
-        }}
-      />
-    );
-  } else if (!designSystemVersion && ploneVersion) {
+  if (!designSystemVersion) {
     return (
       <FormattedMessage
         id="NSW Built with - plone only"
-        defaultMessage="NSW DDS {ploneVersion}"
-        values={{
-          ploneVersion: ploneVersion,
-        }}
-      />
-    );
-  } else if (designSystemVersion && ploneVersion) {
-    return (
-      <FormattedMessage
-        id="NSW Built with - DDS and Plone"
-        defaultMessage="NSW DDS {ddsVersion} {ploneVersion}"
-        values={{
-          ddsVersion: designSystemVersion,
-          ploneVersion: ploneVersion,
-        }}
+        defaultMessage="NSW DDS Plone"
       />
     );
   }
+
   return (
-    <FormattedMessage id="NSW Built with - Fallback" defaultMessage="NSW DDS" />
+    <FormattedMessage
+      id="NSW Built with - DDS and Plone"
+      defaultMessage="NSW DDS Plone {ddsVersion}"
+      values={{
+        ddsVersion: designSystemVersion,
+      }}
+    />
   );
 }

--- a/src/customizations/volto/components/theme/Footer/Footer.jsx
+++ b/src/customizations/volto/components/theme/Footer/Footer.jsx
@@ -7,8 +7,10 @@ import { getTextColourUtilityForPaletteName } from 'nsw-design-system-plone6/hel
 import { useEffect } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
 import { getSubFooter } from 'volto-subfooter';
+
+import { DesignSystemVersionInformation } from 'nsw-design-system-plone6/components/DesignSystemVersionInformation';
+import { Link } from 'react-router-dom';
 
 // TODO: Would dynamically importing these reduce bundle size?
 import FacebookSVG from '@mdi/svg/svg/facebook.svg';
@@ -246,7 +248,7 @@ function Footer() {
               <div className="nsw-footer__built">
                 {intl.formatMessage(messages.builtWith)}
                 <a href="https://digitalnsw.pretagov.com.au" rel="external">
-                  Plone 6 NSW DS
+                  <DesignSystemVersionInformation />
                 </a>
               </div>
             </div>


### PR DESCRIPTION
Updated to the following format:

`Built with NSW DDS Plone 3.11`

DDS version is fetched from the package info. If, for some reason, we fail to get the DDS version from the package info, we fallback to displaying it without the version