### PR TITLE
Display the default hero block if no variation is selected

### DIFF
--- a/src/customizations/volto/components/manage/Blocks/HeroImageLeft/View.jsx
+++ b/src/customizations/volto/components/manage/Blocks/HeroImageLeft/View.jsx
@@ -15,7 +15,7 @@ const View = ({ data, ...props }) => {
     return item.id === data.variation;
   });
 
-  if (variation.id === 'default') {
+  if (!variation || variation.id === 'default') {
     return (
       <Hero
         title={data.title}


### PR DESCRIPTION
This PR fixes a crash when creating a new hero block, or displaying one in the NSW theme that was created in default Volto.