### PR TITLE
Global alert

### DIFF
--- a/src/components/Blocks/GlobalAlert/Edit.jsx
+++ b/src/components/Blocks/GlobalAlert/Edit.jsx
@@ -28,7 +28,7 @@ export function GlobalAlertEdit(props) {
 
   return (
     <>
-      <GlobalAlertView {...data} />
+      <GlobalAlertView data={data} />
       <SidebarPortal selected={selected}>
         <SidebarContents {...props} />
       </SidebarPortal>

--- a/src/components/Blocks/GlobalAlert/Edit.jsx
+++ b/src/components/Blocks/GlobalAlert/Edit.jsx
@@ -1,0 +1,37 @@
+import config from '@plone/registry';
+import { BlockDataForm, SidebarPortal } from '@plone/volto/components';
+import { GlobalAlertView } from './View';
+import { globalAlertSchema } from './schema';
+
+function SidebarContents(props) {
+  const { data, block, onChangeBlock } = props;
+  const schema = globalAlertSchema({ ...props });
+
+  return (
+    <BlockDataForm
+      schema={schema}
+      title={`${config.blocks.blocksConfig[data['@type']].title}`}
+      onChangeField={(id, value) => {
+        onChangeBlock(block, {
+          ...data,
+          [id]: value,
+        });
+      }}
+      formData={data}
+      block={block}
+    />
+  );
+}
+
+export function GlobalAlertEdit(props) {
+  const { data, selected } = props;
+
+  return (
+    <>
+      <GlobalAlertView {...data} />
+      <SidebarPortal selected={selected}>
+        <SidebarContents {...props} />
+      </SidebarPortal>
+    </>
+  );
+}

--- a/src/components/Blocks/GlobalAlert/View.jsx
+++ b/src/components/Blocks/GlobalAlert/View.jsx
@@ -1,0 +1,5 @@
+import { GlobalAlert } from 'nsw-design-system-plone6/components/Components/GlobalAlert';
+
+export function GlobalAlertView({ title, description, buttonText, url }) {
+  return <GlobalAlert title={title} description={description} buttonText={buttonText} url={url} />;
+}

--- a/src/components/Blocks/GlobalAlert/View.jsx
+++ b/src/components/Blocks/GlobalAlert/View.jsx
@@ -1,5 +1,6 @@
 import { GlobalAlert } from 'nsw-design-system-plone6/components/Components/GlobalAlert';
 
-export function GlobalAlertView({ title, description, buttonText, url }) {
+export function GlobalAlertView({ data }) {
+  const { title, description, buttonText, url } = data;
   return <GlobalAlert title={title} description={description} buttonText={buttonText} url={url} />;
 }

--- a/src/components/Blocks/GlobalAlert/index.js
+++ b/src/components/Blocks/GlobalAlert/index.js
@@ -1,0 +1,3 @@
+export { GlobalAlertEdit } from './Edit';
+export { globalAlertSchema } from './schema';
+export { GlobalAlertView } from './View';

--- a/src/components/Blocks/GlobalAlert/schema.js
+++ b/src/components/Blocks/GlobalAlert/schema.js
@@ -1,0 +1,40 @@
+export function globalAlertSchema({ intl }) {
+  return {
+    fieldsets: [
+      {
+        id: 'default',
+        title: 'Default',
+        fields: ['title', 'description', 'buttonText', 'url'],
+        required: ['title'],
+      },
+    ],
+    required: [],
+    properties: {
+      title: {
+        title: intl.formatMessage({
+          id: 'Title',
+          defaultMessage: 'Title',
+        }),
+      },
+      description: {
+        title: intl.formatMessage({
+          id: 'Description',
+          defaultMessage: 'Description',
+        }),
+      },
+      buttonText: {
+        title: intl.formatMessage({
+          id: 'Button text',
+          defaultMessage: 'Button text',
+        }),
+      },
+      url: {
+        title: intl.formatMessage({
+          id: 'Link',
+          defaultMessage: 'Link',
+        }),
+        widget: 'url',
+      },
+    },
+  };
+}

--- a/src/components/Components/GlobalAlert.jsx
+++ b/src/components/Components/GlobalAlert.jsx
@@ -1,0 +1,23 @@
+export function GlobalAlert({ title, description, buttonText, link }) {
+  <div class="nsw-global-alert js-global-alert" role="alert">
+    <div class="nsw-global-alert__wrapper">
+      <div class="nsw-global-alert__content">
+        <div class="nsw-global-alert__title">{title}</div>
+        {description ? <p>{description}</p> : null}
+      </div>
+      {buttonText && link ? (
+        <p>
+          <a href={link} class="nsw-button nsw-button--white">
+            {buttonText}
+          </a>
+        </p>
+      ) : null}
+      <button class="nsw-icon-button js-close-alert" type="button" aria-expanded="true">
+        <span class="material-icons nsw-material-icons" focusable="false" aria-hidden="true">
+          close
+        </span>
+        <span class="sr-only">Close message</span>
+      </button>
+    </div>
+  </div>;
+}

--- a/src/components/Components/GlobalAlert.jsx
+++ b/src/components/Components/GlobalAlert.jsx
@@ -1,23 +1,25 @@
-export function GlobalAlert({ title, description, buttonText, link }) {
-  <div class="nsw-global-alert js-global-alert" role="alert">
-    <div class="nsw-global-alert__wrapper">
-      <div class="nsw-global-alert__content">
-        <div class="nsw-global-alert__title">{title}</div>
-        {description ? <p>{description}</p> : null}
+export function GlobalAlert({ title, description, buttonText, url }) {
+  return (
+    <div className="nsw-global-alert js-global-alert" role="alert">
+      <div className="nsw-global-alert__wrapper">
+        <div className="nsw-global-alert__content">
+          <div className="nsw-global-alert__title">{title ?? 'placeholder'}</div>
+          {description ? <p>{description}</p> : null}
+        </div>
+        {buttonText && url ? (
+          <p>
+            <a href={url} className="nsw-button nsw-button--white">
+              {buttonText}
+            </a>
+          </p>
+        ) : null}
+        <button className="nsw-icon-button js-close-alert" type="button" aria-expanded="true">
+          <span className="material-icons nsw-material-icons" focusable="false" aria-hidden="true">
+            close
+          </span>
+          <span className="sr-only">Close message</span>
+        </button>
       </div>
-      {buttonText && link ? (
-        <p>
-          <a href={link} class="nsw-button nsw-button--white">
-            {buttonText}
-          </a>
-        </p>
-      ) : null}
-      <button class="nsw-icon-button js-close-alert" type="button" aria-expanded="true">
-        <span class="material-icons nsw-material-icons" focusable="false" aria-hidden="true">
-          close
-        </span>
-        <span class="sr-only">Close message</span>
-      </button>
     </div>
-  </div>;
+  );
 }

--- a/src/components/Components/GlobalAlert.jsx
+++ b/src/components/Components/GlobalAlert.jsx
@@ -1,9 +1,15 @@
+import * as React from 'react';
+
+// This component does have a JavaScript file, but it's only for adding `hidden`
+//    to the alert. This was as of 3.16.1, so things may change.
 export function GlobalAlert({ title, description, buttonText, url }) {
+  const [isHidden, hideAlert] = React.useReducer(() => true, false);
+
   return (
-    <div className="nsw-global-alert js-global-alert" role="alert">
+    <div className="nsw-global-alert js-global-alert" role="alert" hidden={isHidden ? 'hidden' : null}>
       <div className="nsw-global-alert__wrapper">
         <div className="nsw-global-alert__content">
-          <div className="nsw-global-alert__title">{title ?? 'placeholder'}</div>
+          <div className="nsw-global-alert__title">{title}</div>
           {description ? <p>{description}</p> : null}
         </div>
         {buttonText && url ? (
@@ -13,7 +19,7 @@ export function GlobalAlert({ title, description, buttonText, url }) {
             </a>
           </p>
         ) : null}
-        <button className="nsw-icon-button js-close-alert" type="button" aria-expanded="true">
+        <button className="nsw-icon-button js-close-alert" type="button" aria-expanded="true" onClick={hideAlert}>
           <span className="material-icons nsw-material-icons" focusable="false" aria-hidden="true">
             close
           </span>

--- a/src/components/Components/Masthead.jsx
+++ b/src/components/Components/Masthead.jsx
@@ -1,12 +1,9 @@
 import cx from 'classnames';
 
-const Masthead = ({ lightMode }) => {
+export function Masthead({ lightMode }) {
   return (
     <div className={cx('nsw-masthead', { 'nsw-masthead--light': lightMode })}>
       <div className="nsw-container">A NSW Government website</div>
     </div>
   );
-};
-
-export { Masthead };
-export default Masthead;
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -23,6 +23,7 @@ export {
 export { InPageAlertEdit, InPageAlertView } from './Blocks/InPageAlert';
 export { LinkListEdit, LinkListView } from './Blocks/LinkList';
 export { SectionEdit, SectionSchema, SectionView } from './Blocks/Section';
+export * from './Blocks/GlobalAlert';
 export {
   SeparatorEdit,
   SeparatorView,

--- a/src/config/blocks/blockDefinitions.js
+++ b/src/config/blocks/blockDefinitions.js
@@ -92,6 +92,17 @@ export const nswBlocks = [
     },
   },
   {
+    id: 'nsw_globalAlert',
+    title: 'Global alert',
+    icon: sliderSVG,
+    group: 'nsw',
+    view: Components.GlobalAlertView,
+    edit: Components.GlobalAlertEdit,
+    schema: Components.globalAlertSchema,
+    restricted: false,
+    mostUsed: false,
+  },
+  {
     id: 'nsw_inPageAlert',
     title: 'In-page Alert',
     icon: sliderSVG,

--- a/src/config/blocks/blockDefinitions.js
+++ b/src/config/blocks/blockDefinitions.js
@@ -99,7 +99,7 @@ export const nswBlocks = [
     view: Components.GlobalAlertView,
     edit: Components.GlobalAlertEdit,
     schema: Components.globalAlertSchema,
-    restricted: false,
+    restricted: true,
     mostUsed: false,
   },
   {

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -20,15 +20,25 @@ export const updateSettingsConfig = (config) => {
     process?.env?.['RAZZLE_ENABLE_SELF_REGISTRATION'] === 'true' ||
     (typeof window !== 'undefined' &&
       window.env['RAZZLE_ENABLE_SELF_REGISTRATION'] === 'true');
-  config.settings['volto-slots-editor'].slots = {
-    ...config.settings['volto-slots-editor'].slots,
-    aoc: {
-      // TODO: i18n
-      title: 'AOC',
-      description: `Appears in between the lower and upper footer.
+  config.settings['volto-slots-editor'] = {
+    // allowedBlocks: ['video'],
+    showRestricted: true,
+    slots: {
+      ...config.settings['volto-slots-editor'].slots,
+      aoc: {
+        // TODO: i18n
+        title: 'AOC',
+        description: `Appears in between the lower and upper footer.
 When enabled, the built-in AOC will be disabled.
       `,
-    },
+      },
+      beforeMasthead: {
+        // TODO: i18n
+        title: 'Before masthead',
+        description: `Appears as the first contents on the page after the skiplinks.
+      `,
+      },
+    }
   };
 };
 

--- a/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/src/customizations/volto/components/theme/Header/Header.jsx
@@ -8,12 +8,15 @@ import {
   UniversalLink,
 } from '@plone/volto/components';
 
+import { Masthead } from 'nsw-design-system-plone6/components/Components/Masthead';
 import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { useGoogleAnalytics } from 'volto-google-analytics';
 import Navigation from '../Navigation/Navigation';
-import { Masthead } from './Masthead';
+
+import { useVoltoSlotsEditor } from '@plone-collective/volto-slots-editor';
+import config from '@plone/volto/registry';
 
 import MenuSVG from '@material-design-icons/svg/filled/menu.svg';
 import SearchSVG from '@material-design-icons/svg/filled/search.svg';
@@ -110,16 +113,21 @@ const Header = ({ nswDesignSystem }) => {
   }
   useGoogleAnalytics();
 
-  //   TODO: We should be able to use a fragment instead of a div here. Not sure why the `Navigation` component isn't being rendered if we use a fragment.
+  const beforeMastheadSlotData = useVoltoSlotsEditor('beforeMasthead');
+  const BeforeMastheadSlotDisplay = config.getComponent({
+    name: 'VoltoBlocksSlotDisplay',
+  }).component;
+
   return (
     <>
       {/* TODO: Anon-tools and language selector currently don't work nor have a NSW component. Need to integrate. */}
       {/* <Anontools /> */}
       {/* <LanguageSelector /> */}
-      {siteSettings &&
-      siteSettings.show_masthead !== undefined &&
-      !siteSettings.show_masthead ? null : (
-        <Masthead />
+      {siteSettings && siteSettings.show_masthead !== undefined && !siteSettings.show_masthead ? null : (
+        <>
+          {BeforeMastheadSlotDisplay && beforeMastheadSlotData?.enabled === true ? <BeforeMastheadSlotDisplay slot="beforeMasthead" /> : null}
+          <Masthead />
+        </>
       )}
 
       <header className="nsw-header">


### PR DESCRIPTION
This PR adds the 'Global Alert' as a block. This block is disabled from use in the normal block editor and can only be used in 'restricted' block forms, such as the volto-slots-editor.
A `beforeMasthead` slot has been added which is intended to be used alongside the global alert to position it in the NSW recommended location.