### PR TITLE
Fixed list items with multiple values not separating the items

### DIFF
--- a/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
@@ -3,6 +3,24 @@ import { flattenToAppURL } from '@plone/volto/helpers';
 import cx from 'classnames';
 import { useIntl } from 'react-intl';
 
+/**
+ * @param {Object} in
+ * @param {string} in.locale
+ * @param {string|Array<string>} in.labels
+ */
+function formatLabels({ locale, labels }) {
+  if (typeof labels === 'string') {
+    return [labels];
+  }
+  if (typeof window !== 'undefined' && Intl.ListFormat) {
+    return new Intl.ListFormat(locale || 'en', {
+      style: 'short', // All `,` in English
+      type: 'unit',
+    }).format(labels);
+  }
+  return labels.join(',');
+}
+
 // TODO: Customisable datetime format
 const ListItemsTemplate = ({ items, isEditMode, ...data }) => {
   const intl = useIntl();
@@ -28,10 +46,15 @@ const ListItemsTemplate = ({ items, isEditMode, ...data }) => {
           year: 'numeric',
         });
 
-        const label =
+        const labels =
           item[data.labelField] === 'None'
             ? null
             : item[data.labelField?.value];
+        const formattedLabels = formatLabels({
+          locale: intl.locale,
+          labels: labels,
+        });
+
         const tags = [];
         data.tagField?.forEach((field) => {
           let fieldValue = item[field.value];
@@ -50,7 +73,7 @@ const ListItemsTemplate = ({ items, isEditMode, ...data }) => {
           >
             <div className="nsw-list-item__content">
               {data.showLabel ? (
-                <div className="nsw-list-item__label">{label}</div>
+                <div className="nsw-list-item__label">{formattedLabels}</div>
               ) : null}
 
               {data.showDate && date ? (

--- a/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
@@ -6,9 +6,12 @@ import { useIntl } from 'react-intl';
 /**
  * @param {Object} in
  * @param {string} in.locale
- * @param {string|Array<string>} in.labels
+ * @param {null|string|Array<string>} in.labels
  */
 function formatLabels({ locale, labels }) {
+  if (!labels) {
+    return [];
+  }
   if (typeof labels === 'string') {
     return [labels];
   }

--- a/src/customizations/volto/components/manage/Widgets/DatetimeWidget.jsx
+++ b/src/customizations/volto/components/manage/Widgets/DatetimeWidget.jsx
@@ -194,10 +194,8 @@ export class DatetimeWidgetComponent extends Component {
     const moment = this.props.moment.default;
     const datetime = this.getInternalValue();
     const dateOnly = this.getDateOnly();
-    const {SingleDatePicker} = reactDates;
+    const { SingleDatePicker } = reactDates;
     
-    console.log("lang", lang);
-
     return (
       <FormFieldWrapper {...this.props}>
         <div className="date-time-widget-wrapper">


### PR DESCRIPTION
This PR fixes formatting of list item labels when there are multiple values.
If the client has support for `Intl.ListFormat`, it will use that to separate the list up using the correct separator for the given language, otherwise (such as old browsers or on the server), it will default to using `,` as a separator.