### PR TITLE
Fixed "Show all" button in search block facets triggering a form submission

### DIFF
--- a/src/customizations/volto/components/manage/Blocks/Search/components/CheckboxFacet.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/components/CheckboxFacet.jsx
@@ -139,6 +139,7 @@ const CheckboxFacet = (props) => {
           </div>
           {hiddenChoices.length > 0 ? (
             <button
+              type="button"
               className={cx('nsw-filters__more', {
                 'nsw-display-none': isClient && showAll ? true : null,
               })}


### PR DESCRIPTION
This PR sets the `<button>` element used for the _Show all_ button in a facet to be `type="button"`. Buttons are `type="submit"` by default and the `<form>` element introduced in #199 was being submitted when this button was pressed.