### PR TITLE
Fixed search block not resetting results when you remove the value in the search input

### DIFF
--- a/src/customizations/volto/components/manage/Blocks/Search/hocs/withSearch.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/hocs/withSearch.jsx
@@ -301,7 +301,7 @@ const withSearch = (options) => (WrappedComponent) => {
               id,
               query: data.query || {},
               facets: toSearchFacets || facets,
-              searchText: toSearchText || searchText,
+              searchText: toSearchText ? toSearchText.trim() : '',
               sortOn: toSortOn ?? sortOn,
               sortOrder: toSortOrder ?? sortOrder,
               facetSettings,


### PR DESCRIPTION
This PR applies the change made in https://github.com/plone/volto/pull/4837 to the `withSearch` HOC to ensure that the previous search isn't being used if no value is submitted in the HOC.