### PR TITLE
Give the sidebar a high z-index to ensure it stays above the main navigation

### DIFF
--- a/src/theme/edit.scss
+++ b/src/theme/edit.scss
@@ -1,7 +1,8 @@
 @use 'nsw-design-system/src/main';
 
 // Ensure Volto toolbar is above the NSW main navigation
-#toolbar {
+#toolbar,
+#sidebar {
   z-index: 300;
 }
 


### PR DESCRIPTION
The main navigation component of the NSW Design System has a z-index of 200. This is higher than the toolbar and sidebar by default, causing it to appear above the editing interface. The toolbar was given a z-index of 300 in the past to avoid this issue. This PR adds the same z-index to the sidebar to ensure both parts of the admin interface can be used