### PR TITLE
Fix some console exceptions that don't seem to impact users

### DIFF
--- a/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/src/customizations/volto/components/theme/Header/Header.jsx
@@ -101,7 +101,7 @@ const Header = ({ nswDesignSystem }) => {
     })
       .load()
       .then((navigation) => {
-        if (!searchInputController.current) {
+        if (!searchInputController.current && searchInputElement.current) {
           searchInputController.current = new navigation.default(
             searchInputElement.current,
           );

--- a/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -177,12 +177,17 @@ const Navigation = () => {
 
   useEffect(() => {
     if (navigationController.current) {
-      if (navigationController.current.openSubNavElements.length > 0) {
-        navigationController.current.toggleSubNavDesktop();
+      navigationController.current.mainNavIsOpen = false;
+      const isDesktop = navigationController.current.breakpoint.matches;
+      if (isDesktop) {
+        if (navigationController.current.openSubNavElements.length > 0) {
+          navigationController.current.toggleSubNavDesktop();
+        }
+      } else {
+        navigationController.current.mobileHideMainNav({
+          propertyName: 'transform',
+        });
       }
-      navigationController.current.mobileHideMainNav({
-        propertyName: 'transform',
-      });
     }
   }, [location]);
   useEffect(() => {

--- a/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -149,23 +149,31 @@ const Navigation = () => {
 
   const navigationController = useRef(null);
   const mainNavRef = useRef(null);
-  useEffect(() => {
-    if (__CLIENT__ && !navigationController.current) {
-      loadable(
-        () => import('nsw-design-system/src/components/main-nav/main-nav'),
-        { ssr: false },
-      )
-        .load()
-        .then((navigation) => {
-          if (!navigationController.current && mainNavRef) {
-            navigationController.current = new navigation.default(
-              mainNavRef.current,
-            );
-            navigationController.current.init();
-          }
-        });
-    }
-  }, [mainNavRef]);
+  if (
+    __CLIENT__ &&
+    navigationController.current === null &&
+    mainNavRef.current
+  ) {
+    // Set it from null to false to ensure we only attempt to try the loadable once
+    navigationController.current = false;
+    loadable(
+      () => import('nsw-design-system/src/components/main-nav/main-nav'),
+      { ssr: false },
+    )
+      .load()
+      .then((navigation) => {
+        if (!navigationController.current && mainNavRef.current) {
+          navigationController.current = new navigation.default(
+            mainNavRef.current,
+          );
+          navigationController.current.init();
+        }
+      })
+      .catch(() => {
+        // Reset it back to null so we can re-attempt a loadable later
+        navigationController.current = null;
+      });
+  }
 
   useEffect(() => {
     if (navigationController.current) {


### PR DESCRIPTION
- Fixes a sporadic issue where the NSW Header JS initialisation would occur before the React code has replaced the `<a>` element used for starting search with a button to start the search on the current page by ensuring we wait for the client-side search button to be ready before we try to start the header loading code.
- ...