### PR TITLE
Don't erase past apiExpanders

### DIFF
--- a/src/config/apiExpanders.js
+++ b/src/config/apiExpanders.js
@@ -1,5 +1,6 @@
 export const updateApiExpandersConfig = (config) => {
   config.settings.apiExpanders = [
+    ...(config.settings.apiExpanders ?? []),
     {
       match: '',
       GET_CONTENT: ['actions', 'breadcrumbs', 'navigation'],


### PR DESCRIPTION
This ensures we can still configure api expanders in other addons